### PR TITLE
Add Job model, routes and tests

### DIFF
--- a/backend/alembic/versions/aefc29453418_add_jobs_table.py
+++ b/backend/alembic/versions/aefc29453418_add_jobs_table.py
@@ -1,0 +1,39 @@
+"""add jobs table
+
+Revision ID: aefc29453418
+Revises: e33bb845793c
+Create Date: 2025-06-05 18:58:35.023724
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'aefc29453418'
+down_revision: Union[str, None] = 'e33bb845793c'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "jobs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("location", sa.String(), nullable=False),
+        sa.Column("job_type", sa.String(), nullable=False),
+        sa.Column("description", sa.String(), nullable=False),
+        sa.Column("requirements", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_jobs_id"), "jobs", ["id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_jobs_id"), table_name="jobs")
+    op.drop_table("jobs")

--- a/backend/app/db/__init__.py
+++ b/backend/app/db/__init__.py
@@ -1,7 +1,7 @@
 """Database Configuration and Models"""
 
 from .database import Base, get_db, init_db, get_database_url, engine, create_engine_with_retry
-from .models import User
+from .models import User, Job
 
 __all__ = [
     "Base",
@@ -11,4 +11,5 @@ __all__ = [
     "engine",
     "create_engine_with_retry",
     "User",
+    "Job",
 ]

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -38,3 +38,16 @@ class User(Base):
     def clear_reset_token(self):
         """Clear password reset token after use."""
         self.reset_token = None
+
+
+class Job(Base):
+    __tablename__ = "jobs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String, nullable=False)
+    location = Column(String, nullable=False)
+    job_type = Column(String, nullable=False)
+    description = Column(String, nullable=False)
+    requirements = Column(String, nullable=False)
+    created_at = Column(DateTime, default=func.now())
+    updated_at = Column(DateTime, default=func.now(), onupdate=func.now())

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ from contextlib import asynccontextmanager
 from app.utils.logger import setup_logger
 from app.routes.health import router as health_router
 from app.routes.auth import router as auth_router
+from app.routes.jobs import router as jobs_router
 from app.db.database import init_db, engine
 from app.config import get_settings
 
@@ -52,5 +53,6 @@ app.add_middleware(
 # Include routers
 app.include_router(health_router, prefix="/api")
 app.include_router(auth_router, prefix="/api")
+app.include_router(jobs_router, prefix="/api")
 
 logger.info("Application routes configured")

--- a/backend/app/routes/jobs.py
+++ b/backend/app/routes/jobs.py
@@ -1,0 +1,64 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from app.db.database import get_db
+from app.db.models import Job, User
+from app.routes.auth import get_current_user
+from app.schemas.job import JobCreate, JobUpdate, JobResponse
+
+router = APIRouter(prefix="/jobs", tags=["jobs"])
+
+
+async def admin_required(current_user: User = Depends(get_current_user)) -> User:
+    if current_user.role != "admin" and not current_user.is_superuser:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin privileges required")
+    return current_user
+
+
+@router.get("/", response_model=list[JobResponse])
+async def list_jobs(db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(Job))
+    return result.scalars().all()
+
+
+@router.get("/{job_id}", response_model=JobResponse)
+async def get_job(job_id: int, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(Job).where(Job.id == job_id))
+    job = result.scalar_one_or_none()
+    if not job:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+    return job
+
+
+@router.post("/", response_model=JobResponse, dependencies=[Depends(admin_required)])
+async def create_job(job_in: JobCreate, db: AsyncSession = Depends(get_db)):
+    job = Job(**job_in.dict())
+    db.add(job)
+    await db.commit()
+    await db.refresh(job)
+    return job
+
+
+@router.put("/{job_id}", response_model=JobResponse, dependencies=[Depends(admin_required)])
+async def update_job(job_id: int, job_in: JobUpdate, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(Job).where(Job.id == job_id))
+    job = result.scalar_one_or_none()
+    if not job:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+    for field, value in job_in.dict(exclude_unset=True).items():
+        setattr(job, field, value)
+    await db.commit()
+    await db.refresh(job)
+    return job
+
+
+@router.delete("/{job_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(admin_required)])
+async def delete_job(job_id: int, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(Job).where(Job.id == job_id))
+    job = result.scalar_one_or_none()
+    if not job:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+    await db.delete(job)
+    await db.commit()
+    return None

--- a/backend/app/schemas/job.py
+++ b/backend/app/schemas/job.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+from typing import Optional
+from pydantic import BaseModel
+
+
+class JobBase(BaseModel):
+    title: str
+    location: str
+    job_type: str
+    description: str
+    requirements: str
+
+
+class JobCreate(JobBase):
+    pass
+
+
+class JobUpdate(BaseModel):
+    title: Optional[str] = None
+    location: Optional[str] = None
+    job_type: Optional[str] = None
+    description: Optional[str] = None
+    requirements: Optional[str] = None
+
+
+class JobResponse(JobBase):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -1,0 +1,87 @@
+import os
+import sys
+import pytest
+import httpx
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
+
+from app.main import app
+from app.db.models import Base, User, Job
+from app.db.database import get_db
+
+DATABASE_URL = "sqlite+aiosqlite:///./test.db"
+
+import pytest_asyncio
+
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def client():
+    if os.path.exists("./test.db"):
+        os.remove("./test.db")
+    engine = create_async_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+    async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async def override_get_db():
+        async with async_session() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    async with async_session() as session:
+        admin = User(email="admin@example.com", username="admin", role="admin")
+        admin.set_password("password")
+        session.add(admin)
+        await session.commit()
+
+    transport = httpx.ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as ac:
+        yield ac
+
+    app.dependency_overrides.clear()
+    await engine.dispose()
+    if os.path.exists("./test.db"):
+        os.remove("./test.db")
+
+
+@pytest.mark.asyncio
+async def test_admin_job_crud(client: AsyncClient):
+    # Login as admin
+    res = await client.post(
+        "/api/auth/login",
+        json={"email": "admin@example.com", "password": "password"},
+    )
+    assert res.status_code == 200
+    token = res.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # Create job
+    job_data = {
+        "title": "Software Engineer",
+        "location": "Remote",
+        "job_type": "Full-time",
+        "description": "Develop software",
+        "requirements": "Python",
+    }
+    res = await client.post("/api/jobs/", json=job_data, headers=headers)
+    assert res.status_code == 200
+    job_id = res.json()["id"]
+
+    # Update job
+    res = await client.put(f"/api/jobs/{job_id}", json={"title": "Senior Engineer"}, headers=headers)
+    assert res.status_code == 200
+    assert res.json()["title"] == "Senior Engineer"
+
+    # Delete job
+    res = await client.delete(f"/api/jobs/{job_id}", headers=headers)
+    assert res.status_code == 204
+
+    # Ensure deletion
+    res = await client.get(f"/api/jobs/{job_id}")
+    assert res.status_code == 404


### PR DESCRIPTION
## Summary
- create Job SQLAlchemy model
- expose Job in database package
- generate alembic migration for jobs table
- create Job schemas
- implement CRUD router with admin dependency
- register jobs router
- add tests for admin job endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e84975148327b5d9b74bbaedd44d