### PR TITLE
Add default admin user and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ fastapi-react-starter/
 
    The Swagger docs will be available at http://localhost:8000/docs
 
+   The first start creates an administrator account with:
+
+   - **Username:** `admin`
+   - **Password:** `admin`
+
 ### Automated Setup Scripts
 
 For your convenience, this project includes automated setup scripts for both Windows and Linux/Mac:


### PR DESCRIPTION
## Summary
- create initial admin account during DB initialization
- document default admin credentials in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842c1a67994832788d731e44a7f39ff