### PR TITLE
Add messenger contacts section

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,19 +1,19 @@
-
-import  { useEffect } from "react";
-import Navbar       from "./components/Navbar";
-import Hero         from "./components/Hero";
-import About        from "./components/About";
-import Services     from "./components/Services";
-import JobList      from "./components/JobList";
-import Testimonials from "./components/Testimonials";
-import Contact      from "./components/Contact";
-import Footer       from "./components/Footer";
+import { useEffect } from 'react'
+import Navbar from './components/Navbar'
+import Hero from './components/Hero'
+import About from './components/About'
+import Services from './components/Services'
+import JobList from './components/JobList'
+import Testimonials from './components/Testimonials'
+import Contact from './components/Contact'
+import Footer from './components/Footer'
+import MessengerContacts from './components/MessengerContacts'
 
 export default function App() {
   useEffect(() => {
     // Включаем плавное скроллирование по якорям (anchor links)
-    document.documentElement.style.scrollBehavior = "smooth";
-  }, []);
+    document.documentElement.style.scrollBehavior = 'smooth'
+  }, [])
 
   return (
     <div className="flex flex-col min-h-screen">
@@ -26,9 +26,10 @@ export default function App() {
         <JobList />
         <Testimonials />
         <Contact />
+        <MessengerContacts />
       </main>
 
       <Footer />
     </div>
-  );
+  )
 }

--- a/frontend/src/components/MessengerContacts.tsx
+++ b/frontend/src/components/MessengerContacts.tsx
@@ -1,0 +1,35 @@
+import { useLanguage } from '../context/LanguageContext'
+
+export default function MessengerContacts() {
+  const { t } = useLanguage()
+
+  const phone = '+359 881 234 567' // contact phone number
+
+  return (
+    <section id="messengers" className="py-10 bg-gray-100">
+      <div className="container mx-auto px-6 text-center">
+        <h2 className="text-2xl font-semibold mb-4">{t('messengers.title')}</h2>
+        <div className="flex flex-col items-center space-y-2 text-lg">
+          <div>
+            <span className="font-medium mr-1">{t('messengers.viber')}:</span>
+            <a
+              href={`viber://chat?number=${phone.replace(/\s+/g, '')}`}
+              className="text-gray-900 hover:underline"
+            >
+              {phone}
+            </a>
+          </div>
+          <div>
+            <span className="font-medium mr-1">{t('messengers.whatsapp')}:</span>
+            <a
+              href={`https://wa.me/${phone.replace(/\D/g, '')}`}
+              className="text-gray-900 hover:underline"
+            >
+              {phone}
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/i18n/bg.json
+++ b/frontend/src/i18n/bg.json
@@ -76,5 +76,10 @@
     "en": "English",
     "ru": "Русский",
     "bg": "Български"
+  },
+  "messengers": {
+    "title": "Свържете се с нас в месинджърите",
+    "viber": "Viber",
+    "whatsapp": "WhatsApp"
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -76,5 +76,10 @@
     "en": "English",
     "ru": "Русский",
     "bg": "Български"
+  },
+  "messengers": {
+    "title": "Contact us via messengers",
+    "viber": "Viber",
+    "whatsapp": "WhatsApp"
   }
 }

--- a/frontend/src/i18n/ru.json
+++ b/frontend/src/i18n/ru.json
@@ -76,5 +76,10 @@
     "en": "English",
     "ru": "Русский",
     "bg": "Български"
+  },
+  "messengers": {
+    "title": "Свяжитесь с нами в мессенджерах",
+    "viber": "Viber",
+    "whatsapp": "WhatsApp"
   }
 }


### PR DESCRIPTION
## Summary
- translate messenger section for EN, RU and BG locales
- create MessengerContacts component displaying Viber and WhatsApp numbers
- place MessengerContacts above the footer in App

## Testing
- `pre-commit run --files frontend/src/i18n/en.json frontend/src/i18n/ru.json frontend/src/i18n/bg.json frontend/src/components/MessengerContacts.tsx frontend/src/App.tsx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842c29900f083278cb4ef2db3a18275