### PR TITLE
Fix admin trailing slash routes

### DIFF
--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -54,6 +54,10 @@ const routes = {
       path: 'admin',
       element: <AdminLogin />,
     },
+    {
+      path: 'admin/',
+      element: <AdminLogin />,
+    },
   ],
   protected: [
     {
@@ -65,7 +69,15 @@ const routes = {
       element: <JobAdmin />,
     },
     {
+      path: 'admin/jobs/',
+      element: <JobAdmin />,
+    },
+    {
       path: 'admin/forms',
+      element: <AdminForms />,
+    },
+    {
+      path: 'admin/forms/',
       element: <AdminForms />,
     },
   ],


### PR DESCRIPTION
## Summary
- handle trailing slashes for admin routes

## Testing
- `pytest -q`
- `npm run format:check` *(fails: code style issues)*
- `npm run typecheck` *(fails: cannot find types)*


------
https://chatgpt.com/codex/tasks/task_e_6842e04ca77c83278749d039b13daa44