### PR TITLE
Fix admin trailing slash routes

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,21 +1,22 @@
 // frontend/src/index.tsx
-import React from "react";
-import { createRoot } from "react-dom/client";
-import App from "./App";
-import "./index.css";       // Подключаем CSS с @tailwind
-import "./i18n/en.json";    // Подключаем локализацию (если используете напрямую)
-import { LanguageProvider } from "./context/LanguageContext";
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { RouterProvider } from 'react-router-dom'
+import { router } from './routes/router'
+import './index.css' // Подключаем CSS с @tailwind
+import './i18n/en.json' // Подключаем локализацию (если используете напрямую)
+import { LanguageProvider } from './context/LanguageContext'
 
-const container = document.getElementById("root");
+const container = document.getElementById('root')
 if (!container) {
-  throw new Error("Корневой контейнер с id 'root' не найден");
+  throw new Error("Корневой контейнер с id 'root' не найден")
 }
 
-const root = createRoot(container);
+const root = createRoot(container)
 root.render(
   <React.StrictMode>
     <LanguageProvider>
-      <App />
+      <RouterProvider router={router} />
     </LanguageProvider>
   </React.StrictMode>
-);
+)

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -54,6 +54,10 @@ const routes = {
       path: 'admin',
       element: <AdminLogin />,
     },
+    {
+      path: 'admin/',
+      element: <AdminLogin />,
+    },
   ],
   protected: [
     {
@@ -65,7 +69,15 @@ const routes = {
       element: <JobAdmin />,
     },
     {
+      path: 'admin/jobs/',
+      element: <JobAdmin />,
+    },
+    {
       path: 'admin/forms',
+      element: <AdminForms />,
+    },
+    {
+      path: 'admin/forms/',
       element: <AdminForms />,
     },
   ],


### PR DESCRIPTION
## Summary
- handle trailing slashes for admin routes
- update entrypoint to mount router

## Testing
- `pytest -q`
- `npm run format:check` *(fails: code style issues)*
- `npm run typecheck` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6842e04ca77c83278749d039b13daa44