### PR TITLE
Fix admin routing

### DIFF
--- a/frontend/src/components/ui/StatusDot.tsx
+++ b/frontend/src/components/ui/StatusDot.tsx
@@ -1,5 +1,5 @@
-export function StatusDot({ status }) {
-  const colors = {
+export function StatusDot({ status }: { status: 'healthy' | 'error' | 'loading' }) {
+  const colors: Record<'healthy' | 'error' | 'loading', string> = {
     healthy: 'bg-green-500',
     error: 'bg-red-500',
     loading: 'bg-gray-300 animate-pulse',

--- a/frontend/src/components/ui/ThemeToggle.tsx
+++ b/frontend/src/components/ui/ThemeToggle.tsx
@@ -1,5 +1,5 @@
 import { MoonIcon, SunIcon } from 'lucide-react'
-import { Button } from './Button'
+import Button from './Button'
 import { useAppState, useAppDispatch, setTheme } from '../../context/AppContext'
 import { Theme } from '../../types'
 

--- a/frontend/src/features/auth/LoginForm.tsx
+++ b/frontend/src/features/auth/LoginForm.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom'
 import { Suspense, cache } from 'react'
-import { Button } from '@/components/ui/Button'
-import { Input } from '@/components/ui/input'
+import Button from '@/components/ui/Button'
+import Input from '@/components/ui/input'
 import {
   Card,
   CardContent,

--- a/frontend/src/features/auth/RegisterForm.tsx
+++ b/frontend/src/features/auth/RegisterForm.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom'
 import { Suspense, cache } from 'react'
-import { Button } from '@/components/ui/Button'
-import { Input } from '@/components/ui/input'
+import Button from '@/components/ui/Button'
+import Input from '@/components/ui/input'
 import {
   Card,
   CardContent,

--- a/frontend/src/layouts/RootLayout.tsx
+++ b/frontend/src/layouts/RootLayout.tsx
@@ -3,7 +3,7 @@ import { AppProvider } from '../context/AppContext'
 import { Notification } from '../components/ui/Notification'
 import { ThemeToggle } from '../components/ui/ThemeToggle'
 import { useAuth } from '../context/AuthContext'
-import { Button } from '../components/ui/Button'
+import Button from '../components/ui/Button'
 
 const publicNavLinks = [
   { to: '/', label: 'Home' },

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -4,7 +4,7 @@ import { CircleCheck, Sparkles } from 'lucide-react'
 import { ErrorBoundary } from '../features/health/ErrorBoundary'
 import { HealthStatus } from '../features/health/HealthStatus'
 import { LoadingStatus } from '../features/health/LoadingStatus'
-import { Button } from '../components/ui/Button'
+import Button from '../components/ui/Button'
 
 type FeatureItem = {
   id: string
@@ -38,12 +38,12 @@ export default function Home() {
 
       <div className="grid gap-6">
         <div
-          className="p-6 rounded-lg border border-gray-200 dark:border-gray-700 
+          className="p-6 rounded-lg border border-gray-200 dark:border-gray-700
           bg-white dark:bg-gray-800 shadow-sm hover:shadow-md transition-all"
         >
           <div className="flex items-start space-x-4">
             <div
-              className="flex-shrink-0 p-2 rounded-lg bg-blue-50 dark:bg-blue-900/30 
+              className="flex-shrink-0 p-2 rounded-lg bg-blue-50 dark:bg-blue-900/30
               text-blue-600 dark:text-blue-400"
             >
               <CircleCheck />
@@ -62,12 +62,12 @@ export default function Home() {
         </div>
 
         <div
-          className="p-6 rounded-lg border border-gray-200 dark:border-gray-700 
+          className="p-6 rounded-lg border border-gray-200 dark:border-gray-700
           bg-white dark:bg-gray-800 shadow-sm hover:shadow-md transition-all"
         >
           <div className="flex items-start space-x-4">
             <div
-              className="flex-shrink-0 p-2 rounded-lg bg-green-50 dark:bg-green-900/30 
+              className="flex-shrink-0 p-2 rounded-lg bg-green-50 dark:bg-green-900/30
               text-green-600 dark:text-green-400"
             >
               <Sparkles />

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -50,35 +50,27 @@ const routes = {
       path: 'register',
       element: <Register />,
     },
-    {
-      path: 'admin',
-      element: <AdminLogin />,
-    },
-    {
-      path: 'admin/',
-      element: <AdminLogin />,
-    },
   ],
+  admin: {
+    public: {
+      index: true,
+      element: <AdminLogin />,
+    },
+    protected: [
+      {
+        path: 'jobs',
+        element: <JobAdmin />,
+      },
+      {
+        path: 'forms',
+        element: <AdminForms />,
+      },
+    ],
+  },
   protected: [
     {
       path: 'dashboard',
       element: <Dashboard />,
-    },
-    {
-      path: 'admin/jobs',
-      element: <JobAdmin />,
-    },
-    {
-      path: 'admin/jobs/',
-      element: <JobAdmin />,
-    },
-    {
-      path: 'admin/forms',
-      element: <AdminForms />,
-    },
-    {
-      path: 'admin/forms/',
-      element: <AdminForms />,
     },
   ],
 }
@@ -102,6 +94,21 @@ export const router = createBrowserRouter([
         ...route,
         element: withSuspense(route.element),
       })),
+
+      // Admin routes
+      {
+        path: 'admin',
+        children: [
+          {
+            index: true,
+            element: withSuspense(routes.admin.public.element),
+          },
+          ...routes.admin.protected.map((route) => ({
+            ...route,
+            element: withProtection(route.element),
+          })),
+        ],
+      },
 
       // Protected routes
       ...routes.protected.map((route) => ({


### PR DESCRIPTION
## Summary
- fix incorrect UI imports to default exports
- group admin routes in router
- expose nested `/admin` paths for login and admin pages

## Testing
- `pre-commit run --files frontend/src/components/ui/StatusDot.tsx frontend/src/components/ui/ThemeToggle.tsx frontend/src/features/auth/LoginForm.tsx frontend/src/features/auth/RegisterForm.tsx frontend/src/layouts/RootLayout.tsx frontend/src/pages/Home.tsx`
- `pre-commit run --files frontend/src/routes/router.tsx`
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6842f47aa5e48327abd2d49508e596d8