### PR TITLE
Refactor admin sidebar handling

### DIFF
--- a/frontend/src/layouts/AdminLayout.tsx
+++ b/frontend/src/layouts/AdminLayout.tsx
@@ -1,37 +1,12 @@
 // frontend/src/layouts/AdminLayout.tsx
 import React from 'react'
-import { Link, Outlet, useNavigate } from 'react-router-dom'
-import { useAuth } from '../context/AuthContext'
-import Button from '../components/ui/Button'
+import { Outlet } from 'react-router-dom'
+import AdminSidebar from '../components/admin/AdminSidebar'
 
 export default function AdminLayout() {
-  const navigate = useNavigate()
-  const { isAuthenticated, logout } = useAuth()
-
   return (
     <div className="min-h-screen flex">
-      {/* Админский сайдбар */}
-      <aside className="w-60 bg-gray-100 p-4 flex flex-col justify-between">
-        <div>
-          <h2 className="text-2xl font-bold mb-4">Admin Panel</h2>
-          <ul className="space-y-2">
-            <li><Link to="dashboard" className="hover:underline">Dashboard</Link></li>
-            <li><Link to="jobs"      className="hover:underline">Jobs</Link></li>
-            <li><Link to="jobs/new"  className="hover:underline">+ New Job</Link></li>
-            <li><Link to="applicants" className="hover:underline">Applicants</Link></li>
-          </ul>
-        </div>
-        {isAuthenticated && (
-          <Button variant="ghost" onClick={() => {
-            logout()
-            navigate('/admin/login')
-          }}>
-            Logout
-          </Button>
-        )}
-      </aside>
-
-      {/* Контент админки */}
+      <AdminSidebar />
       <main className="flex-1 bg-white p-6">
         <Outlet />
       </main>

--- a/frontend/src/pages/AdminForms.tsx
+++ b/frontend/src/pages/AdminForms.tsx
@@ -1,18 +1,14 @@
 // pages/AdminForms.tsx
 
-import AdminHeader      from '../components/admin/AdminHeader'
-import AdminSidebar     from '../components/admin/AdminSidebar'
-import AdminApplicants  from '../components/admin/AdminApplicants'
+import AdminHeader     from '../components/admin/AdminHeader'
+import AdminApplicants from '../components/admin/AdminApplicants'
 
 export default function AdminForms() {
   return (
-    <div className="flex h-full">
-      <AdminSidebar />
-      <div className="flex-1">
-        <AdminHeader />
-        <div className="p-6">
-          <AdminApplicants />
-        </div>
+    <div className="flex-1">
+      <AdminHeader />
+      <div className="p-6">
+        <AdminApplicants />
       </div>
     </div>
   )

--- a/frontend/src/pages/JobAdmin.tsx
+++ b/frontend/src/pages/JobAdmin.tsx
@@ -1,18 +1,14 @@
 // pages/JobAdmin.tsx
 
-import AdminHeader    from '../components/admin/AdminHeader'
-import AdminSidebar   from '../components/admin/AdminSidebar'
-import AdminJobList   from '../components/admin/AdminJobList'
+import AdminHeader  from '../components/admin/AdminHeader'
+import AdminJobList from '../components/admin/AdminJobList'
 
 export default function JobAdmin() {
   return (
-    <div className="flex h-full">
-      <AdminSidebar />
-      <div className="flex-1">
-        <AdminHeader />
-        <div className="p-6">
-          <AdminJobList />
-        </div>
+    <div className="flex-1">
+      <AdminHeader />
+      <div className="p-6">
+        <AdminJobList />
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- centralize sidebar menu in `AdminLayout`
- remove sidebar from admin pages so they use the layout sidebar

## Testing
- `pnpm run typecheck` *(fails: cannot find many modules)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_686cfa8c26088327b15f48e7a51ecc18