### PR TITLE
Use Navbar component in client layout

### DIFF
--- a/frontend/src/layouts/ClientLayout.tsx
+++ b/frontend/src/layouts/ClientLayout.tsx
@@ -1,16 +1,8 @@
 // frontend/src/layouts/ClientLayout.tsx
 import React from 'react'
-import { Link, Outlet } from 'react-router-dom'
+import { Outlet } from 'react-router-dom'
 import { ThemeToggle } from '../components/ui/ThemeToggle'
-import LanguageSwitcher from '../components/LanguageSwitcher' // ваш компонент для выбора языка
-
-const publicNavLinks = [
-  { to: '/',         label: 'Home'     },
-  { to: '/about',    label: 'About'    },
-  { to: '/services', label: 'Services' },
-  { to: '/jobs',     label: 'Jobs'     },
-  { to: '/contact',  label: 'Contact'  },
-] as const
+import Navbar from '../components/Navbar'
 
 export default function ClientLayout() {
   const year = new Date().getFullYear()
@@ -18,31 +10,10 @@ export default function ClientLayout() {
   return (
     <div className="min-h-screen flex flex-col bg-gray-50 dark:bg-gray-900 transition-colors">
       {/* HEADER */}
-      <header className="bg-white dark:bg-gray-800 shadow">
-        <div className="container mx-auto px-6 py-4 flex items-center justify-between">
-          {/* Логотип или название */}
-          <h1 className="text-xl font-bold text-gray-900 dark:text-white">HR Agency</h1>
-          
-          {/* Основное меню */}
-          <nav className="flex space-x-6">
-            {publicNavLinks.map(({ to, label }) => (
-              <Link
-                key={to}
-                to={to}
-                className="px-3 py-2 rounded-md text-sm font-medium text-gray-900 dark:text-white hover:text-gray-600 dark:hover:text-gray-300"
-              >
-                {label}
-              </Link>
-            ))}
-          </nav>
-
-          {/* Тогглер темы и селектор языка */}
-          <div className="flex items-center space-x-4">
-            <ThemeToggle />
-            <LanguageSwitcher />
-          </div>
-        </div>
-      </header>
+      <Navbar />
+      <div className="container mx-auto px-6 py-4 flex justify-end">
+        <ThemeToggle />
+      </div>
 
       {/* MAIN CONTENT */}
       <main className="flex-1 container mx-auto px-6 py-8">


### PR DESCRIPTION
## Summary
- import `Navbar` into `ClientLayout`
- remove hardcoded header and render `<Navbar />`
- display `ThemeToggle` under the navbar

## Testing
- `pre-commit run --files frontend/src/layouts/ClientLayout.tsx`

------
https://chatgpt.com/codex/tasks/task_e_686d009bb1f88327b6fcf205bb4bd7fe