### PR TITLE
Handle 401 in AdminApplicants

### DIFF
--- a/frontend/src/components/admin/AdminApplicants.tsx
+++ b/frontend/src/components/admin/AdminApplicants.tsx
@@ -1,5 +1,7 @@
 // frontend/src/components/admin/AdminApplicants.tsx
 import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../../context/AuthContext'
 
 interface Applicant {
   id: number
@@ -16,6 +18,8 @@ export default function AdminApplicants() {
   const [apps, setApps] = useState<Applicant[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string|null>(null)
+  const navigate = useNavigate()
+  const { logout } = useAuth()
 
   useEffect(() => {
     (async () => {
@@ -28,6 +32,11 @@ export default function AdminApplicants() {
           headers: { Authorization: `Bearer ${token}` }
         })
         if (!res.ok) {
+          if (res.status === 401) {
+            logout()
+            navigate('/admin/login')
+            return
+          }
           throw new Error(`Server ${res.status}: ${await res.text()}`)
         }
         setApps(await res.json())


### PR DESCRIPTION
## Summary
- redirect to login if fetching forms returns 401

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686d09632b948327b72d8550f03b398f