### PR TITLE
Implement job admin CRUD

### DIFF
--- a/backend/alembic/versions/9e0ec14d9393_simplify_jobs_table.py
+++ b/backend/alembic/versions/9e0ec14d9393_simplify_jobs_table.py
@@ -1,0 +1,42 @@
+"""simplify jobs table
+
+Revision ID: 9e0ec14d9393
+Revises: aefc29453418
+Create Date: 2025-07-09 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '9e0ec14d9393'
+down_revision: Union[str, None] = 'aefc29453418'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_table('jobs')
+    op.create_table(
+        'jobs',
+        sa.Column('id', sa.String(length=36), primary_key=True),
+        sa.Column('title', sa.String(), nullable=False),
+        sa.Column('description', sa.Text(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('jobs')
+    op.create_table(
+        'jobs',
+        sa.Column('id', sa.String(length=36), primary_key=True),
+        sa.Column('title', sa.String(), nullable=False),
+        sa.Column('description', sa.String(), nullable=False),
+        sa.Column('location', sa.String(), nullable=False),
+        sa.Column('salary_min', sa.Integer(), nullable=False),
+        sa.Column('salary_max', sa.Integer(), nullable=False),
+        sa.Column('is_active', sa.Boolean(), nullable=True, server_default='1'),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+    )

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1,5 +1,6 @@
-from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey, Text
 from sqlalchemy.sql import func
+from uuid import uuid4
 from .database import Base
 from passlib.context import CryptContext
 import secrets
@@ -43,14 +44,9 @@ class User(Base):
 class Job(Base):
     __tablename__ = "jobs"
 
-    id = Column(Integer, primary_key=True, index=True)
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid4()))
     title = Column(String, nullable=False)
-    location = Column(String, nullable=False)
-    job_type = Column(String, nullable=False)
-    description = Column(String, nullable=False)
-    requirements = Column(String, nullable=False)
-    created_at = Column(DateTime, default=func.now())
-    updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
+    description = Column(Text, nullable=False)
 
 
 class ContactForm(Base):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ from app.utils.logger import setup_logger
 from app.routes.health import router as health_router
 from app.routes.auth import router as auth_router
 from app.routes.jobs import router as jobs_router
+from app.routes.admin_jobs import router as admin_jobs_router
 from app.routes.forms import router as forms_router
 from app.db.database import init_db, engine
 from app.config import get_settings
@@ -55,6 +56,7 @@ app.add_middleware(
 app.include_router(health_router, prefix="/api")
 app.include_router(auth_router, prefix="/api")
 app.include_router(jobs_router, prefix="/api")
+app.include_router(admin_jobs_router, prefix="/api")
 app.include_router(forms_router, prefix="/api")
 
 logger.info("Application routes configured")

--- a/backend/app/routes/admin_jobs.py
+++ b/backend/app/routes/admin_jobs.py
@@ -1,0 +1,70 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+
+from app.db.database import get_db
+from app.db.models import Job, User
+from app.routes.auth import get_current_user
+from app.schemas.job import JobCreate, JobUpdate, JobRead
+
+router = APIRouter(prefix="/admin/jobs", tags=["jobs"])
+
+
+def admin_or_manager(current_user: User = Depends(get_current_user)) -> User:
+    if current_user.role not in {"admin", "manager"} and not current_user.is_superuser:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin or manager privileges required",
+        )
+    return current_user
+
+
+@router.get("/", response_model=list[JobRead], dependencies=[Depends(admin_or_manager)])
+async def list_jobs(db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(Job))
+    return result.scalars().all()
+
+
+@router.post("/", response_model=JobRead, dependencies=[Depends(admin_or_manager)])
+async def create_job(job_in: JobCreate, db: AsyncSession = Depends(get_db)):
+    job = Job(**job_in.model_dump())
+    db.add(job)
+    await db.commit()
+    await db.refresh(job)
+    return job
+
+
+@router.get("/{job_id}", response_model=JobRead, dependencies=[Depends(admin_or_manager)])
+async def get_job(job_id: str, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(Job).where(Job.id == job_id))
+    job = result.scalar_one_or_none()
+    if not job:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+    return job
+
+
+@router.put("/{job_id}", response_model=JobRead, dependencies=[Depends(admin_or_manager)])
+async def update_job(job_id: str, job_in: JobUpdate, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(Job).where(Job.id == job_id))
+    job = result.scalar_one_or_none()
+    if not job:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+    for field, value in job_in.model_dump(exclude_unset=True).items():
+        setattr(job, field, value)
+    await db.commit()
+    await db.refresh(job)
+    return job
+
+
+@router.delete(
+    "/{job_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(admin_or_manager)]
+)
+async def delete_job(job_id: str, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(Job).where(Job.id == job_id))
+    job = result.scalar_one_or_none()
+    if not job:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+    await db.delete(job)
+    await db.commit()
+    return None

--- a/backend/app/routes/jobs.py
+++ b/backend/app/routes/jobs.py
@@ -3,62 +3,22 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
 from app.db.database import get_db
-from app.db.models import Job, User
-from app.routes.auth import get_current_user
-from app.schemas.job import JobCreate, JobUpdate, JobResponse
+from app.db.models import Job
+from app.schemas.job import JobRead
 
 router = APIRouter(prefix="/jobs", tags=["jobs"])
 
 
-async def admin_required(current_user: User = Depends(get_current_user)) -> User:
-    if current_user.role != "admin" and not current_user.is_superuser:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin privileges required")
-    return current_user
-
-
-@router.get("/", response_model=list[JobResponse])
+@router.get("/", response_model=list[JobRead])
 async def list_jobs(db: AsyncSession = Depends(get_db)):
     result = await db.execute(select(Job))
     return result.scalars().all()
 
 
-@router.get("/{job_id}", response_model=JobResponse)
-async def get_job(job_id: int, db: AsyncSession = Depends(get_db)):
+@router.get("/{job_id}", response_model=JobRead)
+async def get_job(job_id: str, db: AsyncSession = Depends(get_db)):
     result = await db.execute(select(Job).where(Job.id == job_id))
     job = result.scalar_one_or_none()
     if not job:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
     return job
-
-
-@router.post("/", response_model=JobResponse, dependencies=[Depends(admin_required)])
-async def create_job(job_in: JobCreate, db: AsyncSession = Depends(get_db)):
-    job = Job(**job_in.dict())
-    db.add(job)
-    await db.commit()
-    await db.refresh(job)
-    return job
-
-
-@router.put("/{job_id}", response_model=JobResponse, dependencies=[Depends(admin_required)])
-async def update_job(job_id: int, job_in: JobUpdate, db: AsyncSession = Depends(get_db)):
-    result = await db.execute(select(Job).where(Job.id == job_id))
-    job = result.scalar_one_or_none()
-    if not job:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
-    for field, value in job_in.dict(exclude_unset=True).items():
-        setattr(job, field, value)
-    await db.commit()
-    await db.refresh(job)
-    return job
-
-
-@router.delete("/{job_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(admin_required)])
-async def delete_job(job_id: int, db: AsyncSession = Depends(get_db)):
-    result = await db.execute(select(Job).where(Job.id == job_id))
-    job = result.scalar_one_or_none()
-    if not job:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
-    await db.delete(job)
-    await db.commit()
-    return None

--- a/backend/app/schemas/job.py
+++ b/backend/app/schemas/job.py
@@ -1,14 +1,10 @@
-from datetime import datetime
 from typing import Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, constr
 
 
 class JobBase(BaseModel):
-    title: str
-    location: str
-    job_type: str
-    description: str
-    requirements: str
+    title: constr(min_length=1)
+    description: constr(min_length=1)
 
 
 class JobCreate(JobBase):
@@ -17,16 +13,11 @@ class JobCreate(JobBase):
 
 class JobUpdate(BaseModel):
     title: Optional[str] = None
-    location: Optional[str] = None
-    job_type: Optional[str] = None
     description: Optional[str] = None
-    requirements: Optional[str] = None
 
 
-class JobResponse(JobBase):
-    id: int
-    created_at: datetime
-    updated_at: datetime
+class JobRead(JobBase):
+    id: str
 
     class Config:
         from_attributes = True

--- a/frontend/e2e/jobs.spec.ts
+++ b/frontend/e2e/jobs.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test'
+
+test('create and edit job', async ({ page }) => {
+  // just open form - placeholder for real e2e
+  await page.goto('/admin/jobs/new')
+  await expect(page).toHaveURL(/jobs\/new/)
+})

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,12 +7,15 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
+    "test": "vitest run",
+    "e2e": "playwright test",
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
     "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
+    "@hookform/resolvers": "^5.1.1",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-toast": "^1.2.14",
     "axios": "^1.9.0",
@@ -22,23 +25,31 @@
     "lucide-react": "^0.511.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-hook-form": "^7.60.0",
     "react-i18next": "^15.5.2",
     "react-router-dom": "^7.6.0",
     "tailwind-merge": "^3.3.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/line-clamp": "^0.4.4",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^22.13.4",
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.5",
     "@vitejs/plugin-react": "^4.3.1",
     "autoprefixer": "^10.4.21",
+    "jsdom": "^26.1.0",
+    "playwright": "^1.53.2",
     "postcss": "^8.5.4",
     "prettier": "^3.4.2",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.4.5",
-    "vite": "^5.2.12"
+    "vite": "^5.2.12",
+    "vitest": "^3.2.4"
   }
 }

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  webServer: {
+    command: 'vite dev',
+    port: 5173,
+    reuseExistingServer: true,
+  },
+  testDir: './e2e',
+})

--- a/frontend/src/__tests__/AdminJobForm.test.tsx
+++ b/frontend/src/__tests__/AdminJobForm.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import AdminJobForm from '../components/admin/AdminJobForm'
+import { BrowserRouter } from 'react-router-dom'
+
+it('requires title and description', async () => {
+  render(
+    <BrowserRouter>
+      <AdminJobForm />
+    </BrowserRouter>
+  )
+  await userEvent.click(screen.getByRole('button', { name: /save/i }))
+  expect(await screen.findAllByText(/at least 1 character/i)).toHaveLength(2)
+})

--- a/frontend/src/components/JobList.tsx
+++ b/frontend/src/components/JobList.tsx
@@ -1,46 +1,41 @@
-import { useEffect, useState } from "react";
-import axios from "axios";
-import { useLanguage } from "../context/LanguageContext";
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+import { useLanguage } from '../context/LanguageContext'
 
 interface Job {
-  id: number;
-  title: string;
-  location: string;
-  job_type: string;
-  description: string;
-  requirements?: string;
+  id: string
+  title: string
+  description: string
 }
 
 export default function JobList() {
-  const { t } = useLanguage();
-  const [jobs, setJobs] = useState<Job[] | null>(null);
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
+  const { t } = useLanguage()
+  const [jobs, setJobs] = useState<Job[] | null>(null)
+  const [loading, setLoading] = useState<boolean>(true)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     const fetchJobs = async () => {
       try {
-        const response = await axios.get<Job[]>(
-          "http://localhost:8000/api/jobs"
-        );
-        setJobs(response.data);
+        const response = await axios.get<Job[]>('http://localhost:8000/api/jobs')
+        setJobs(response.data)
       } catch (_) {
-        setError(t("jobs.error"));
+        setError(t('jobs.error'))
       } finally {
-        setLoading(false);
+        setLoading(false)
       }
-    };
-    fetchJobs();
-  }, [t]); // добавляем t в зависимости, чтобы при смене языка сообщение об ошибке тоже обновлялось
+    }
+    fetchJobs()
+  }, [t]) // добавляем t в зависимости, чтобы при смене языка сообщение об ошибке тоже обновлялось
 
   if (loading) {
     return (
       <div id="jobs" className="py-20 bg-gray-100">
         <div className="container mx-auto px-6 text-center">
-          <span className="text-lg text-gray-500">{t("jobs.loading")}</span>
+          <span className="text-lg text-gray-500">{t('jobs.loading')}</span>
         </div>
       </div>
-    );
+    )
   }
 
   if (error) {
@@ -50,15 +45,13 @@ export default function JobList() {
           <span className="text-lg text-red-500">{error}</span>
         </div>
       </div>
-    );
+    )
   }
 
   return (
     <section id="jobs" className="py-20 bg-gray-100">
       <div className="container mx-auto px-6">
-        <h2 className="text-3xl font-semibold text-center mb-8">
-          {t("jobs.title")}
-        </h2>
+        <h2 className="text-3xl font-semibold text-center mb-8">{t('jobs.title')}</h2>
         {jobs && jobs.length > 0 ? (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
             {jobs.map((job) => (
@@ -67,35 +60,17 @@ export default function JobList() {
                 className="p-6 bg-white rounded-lg shadow hover:shadow-lg transition"
               >
                 <h3 className="text-xl font-semibold mb-2">{job.title}</h3>
-                <p className="text-gray-700 mb-1">
-                  <span className="font-medium">{t("nav.jobs")}:</span> {job.location}
-                </p>
-                <p className="text-gray-700 mb-4">
-                  <span className="font-medium">{job.job_type}</span>
-                </p>
-                <p className="text-gray-700 mb-4 line-clamp-3">
-                  {job.description}
-                </p>
-                {job.requirements && (
-                  <details className="mb-4">
-                    <summary className="cursor-pointer text-gray-900">
-                      {t("services.title")} {/* на той же мысли: можно добавить ключ в JSON для “Требования” */}
-                    </summary>
-                    <p className="mt-2 text-gray-600 whitespace-pre-line">
-                      {job.requirements}
-                    </p>
-                  </details>
-                )}
+                <p className="text-gray-700 mb-4 line-clamp-3">{job.description}</p>
                 <button className="mt-2 px-4 py-2 bg-gray-900 text-white rounded hover:bg-gray-800 transition">
-                  {t("hero.button")}
+                  {t('hero.button')}
                 </button>
               </div>
             ))}
           </div>
         ) : (
-          <p className="text-center text-gray-500">{t("jobs.noJobs")}</p>
+          <p className="text-center text-gray-500">{t('jobs.noJobs')}</p>
         )}
       </div>
     </section>
-  );
+  )
 }

--- a/frontend/src/components/admin/AdminJobForm.tsx
+++ b/frontend/src/components/admin/AdminJobForm.tsx
@@ -1,133 +1,88 @@
-// frontend/src/components/admin/AdminJobForm.tsx
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { createJob, updateJob, fetchJobs } from '@/lib/api/jobs'
+import { Job } from '@/types/job'
 import Button from '../ui/Button'
-import Input  from '../ui/input'
-
+import Input from '../ui/input'
 import Textarea from '../ui/Textarea'
+import { useToast } from '@/hooks/use-toast'
 
-interface Job {
-  id?: number
-  title: string
-  location: string
-  job_type: string
-  description: string
-  requirements: string
-}
+const schema = z
+  .object({
+    title: z.string().min(1),
+    description: z.string().min(1),
+  })
+  .strict()
 
 export default function AdminJobForm() {
   const { jobId } = useParams<{ jobId: string }>()
   const editMode = Boolean(jobId)
-  const [job, setJob] = useState<Job>({
-    title: '',
-    location: '',
-    job_type: '',
-    description: '',
-    requirements: '',
-  })
-  const [saving, setSaving] = useState(false)
-  const [error, setError] = useState<string|null>(null)
   const navigate = useNavigate()
+  const { toast } = useToast()
 
-  // при редактировании подгружаем данные
+  const {
+    register,
+    handleSubmit,
+    setError,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<z.infer<typeof schema>>({ resolver: zodResolver(schema) })
+
   useEffect(() => {
     if (!editMode) return
-    (async () => {
+    ;(async () => {
       try {
-        const API = import.meta.env.VITE_API_URL || ''
-        const token = localStorage.getItem('token') || ''
-        const res = await fetch(`${API}/api/jobs/${jobId}`, {
-          headers: { Authorization: `Bearer ${token}` }
-        })
-        if (!res.ok) throw new Error(await res.text())
-        setJob(await res.json())
-      } catch (err: any) {
-        setError(err.message)
+        const res = await fetchJobs()
+        const job = res.find((j) => j.id === jobId)
+        if (job) {
+          reset(job)
+        }
+      } catch (e) {
+        console.error(e)
       }
     })()
-  }, [editMode, jobId])
+  }, [editMode, jobId, reset])
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    setSaving(true)
-    setError(null)
+  const onSubmit = handleSubmit(async (data) => {
     try {
-      const API = import.meta.env.VITE_API_URL || ''
-      const token = localStorage.getItem('token') || ''
-      const url = editMode
-        ? `${API}/api/jobs/${jobId}`
-        : `${API}/api/jobs`
-      const method = editMode ? 'PUT' : 'POST'
-      const res = await fetch(url, {
-        method,
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`
-        },
-        body: JSON.stringify(job)
-      })
-      if (!res.ok) throw new Error(await res.text())
+      if (editMode && jobId) {
+        await updateJob(jobId, data)
+        toast({ title: 'Job updated' })
+      } else {
+        await createJob(data as Job)
+        toast({ title: 'Job created' })
+      }
       navigate('/admin/jobs')
     } catch (err: any) {
-      setError(err.message)
-    } finally {
-      setSaving(false)
+      setError('root', { message: err.message })
     }
-  }
+  })
 
   return (
     <div className="p-6 max-w-xl mx-auto">
-      <h2 className="text-2xl font-semibold mb-4">
-        {editMode ? 'Edit Job' : 'New Job'}
-      </h2>
-      {error && (
-        <p className="mb-4 text-red-600">
-          <strong>Error:</strong> {error}
-        </p>
-      )}
-      <form onSubmit={handleSubmit} className="space-y-4">
+      <h2 className="text-2xl font-semibold mb-4">{editMode ? 'Edit Job' : 'New Job'}</h2>
+      <form onSubmit={onSubmit} className="space-y-4">
         <div>
           <label className="block mb-1 font-medium">Title</label>
-          <Input
-            value={job.title}
-            onChange={e => setJob(j => ({ ...j, title: e.target.value }))}
-          />
-        </div>
-        <div>
-          <label className="block mb-1 font-medium">Location</label>
-          <Input
-            value={job.location}
-            onChange={e => setJob(j => ({ ...j, location: e.target.value }))}
-          />
-        </div>
-        <div>
-          <label className="block mb-1 font-medium">Job Type</label>
-          <Input
-            value={job.job_type}
-            onChange={e => setJob(j => ({ ...j, job_type: e.target.value }))}
-          />
+          <Input {...register('title')} />
+          {errors.title && <p className="text-red-600 text-sm">{errors.title.message}</p>}
         </div>
         <div>
           <label className="block mb-1 font-medium">Description</label>
-          <Textarea
-            value={job.description}
-            onChange={e => setJob(j => ({ ...j, description: e.target.value }))}
-            rows={5}
-          />
+          <Textarea rows={4} {...register('description')} />
+          {errors.description && (
+            <p className="text-red-600 text-sm">{errors.description.message}</p>
+          )}
         </div>
-        <div>
-          <label className="block mb-1 font-medium">Requirements</label>
-          <Textarea
-            value={job.requirements}
-            onChange={e => setJob(j => ({ ...j, requirements: e.target.value }))}
-            rows={5}
-          />
-        </div>
+        {errors.root && <p className="text-red-600">{errors.root.message}</p>}
         <div className="flex space-x-2">
-          <Button type="submit" disabled={saving}>
-            {saving ? 'Saving…' : 'Save'}
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? 'Saving…' : 'Save'}
           </Button>
-          <Button variant="ghost" onClick={() => navigate('/admin/jobs')}>
+          <Button variant="ghost" onClick={() => navigate('/admin/jobs')} type="button">
             Cancel
           </Button>
         </div>

--- a/frontend/src/components/admin/AdminJobList.tsx
+++ b/frontend/src/components/admin/AdminJobList.tsx
@@ -1,54 +1,39 @@
-// frontend/src/components/admin/AdminJobList.tsx
-import { useState, useEffect } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { fetchJobs, deleteJob } from '@/lib/api/jobs'
+import { Job } from '@/types/job'
 import Button from '../ui/Button'
-
-// тип вакансии
-interface Job {
-  id: number
-  title: string
-  description: string
-}
+import { useToast } from '@/hooks/use-toast'
 
 export default function AdminJobList() {
   const [jobs, setJobs] = useState<Job[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const navigate = useNavigate()
+  const { toast } = useToast()
+
+  const load = async () => {
+    setLoading(true)
+    try {
+      const data = await fetchJobs()
+      setJobs(data)
+    } catch (err: any) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
 
   useEffect(() => {
-    const load = async () => {
-      setLoading(true)
-      setError(null)
-      try {
-        // подхватываем из .env
-        const API = import.meta.env.VITE_API_URL || ''
-        const token = localStorage.getItem('token') || ''
-
-        const res = await fetch(`${API}/api/jobs`, {
-          headers: { Authorization: `Bearer ${token}` },
-        })
-
-        if (!res.ok) {
-          // если не 2xx — пробуем прочитать текст ошибки
-          const text = await res.text()
-          throw new Error(
-            `Server responded ${res.status}: ${text || res.statusText}`
-          )
-        }
-
-        // теперь точно можно парсить JSON
-        const data = (await res.json()) as Job[]
-        setJobs(data)
-      } catch (err: any) {
-        setError(err.message)
-      } finally {
-        setLoading(false)
-      }
-    }
-
     load()
   }, [])
+
+  const onDelete = async (id: string) => {
+    if (!confirm('Delete job?')) return
+    await deleteJob(id)
+    toast({ title: 'Job deleted' })
+    load()
+  }
 
   if (loading) return <p className="p-6">Loading…</p>
   if (error)
@@ -62,23 +47,26 @@ export default function AdminJobList() {
     <div className="p-6">
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-2xl font-semibold">Jobs</h2>
-        <Button onClick={() => navigate('/admin/jobs/new')}>
-          New Job
-        </Button>
+        <Button onClick={() => navigate('/admin/jobs/new')}>New Job</Button>
       </div>
-
       {jobs.length === 0 ? (
         <p>No jobs found.</p>
       ) : (
         <ul className="space-y-3">
           {jobs.map((job) => (
-            <li
-              key={job.id}
-              className="border rounded p-4 hover:shadow cursor-pointer"
-              onClick={() => navigate(`/admin/jobs/${job.id}/edit`)}
-            >
-              <h3 className="font-medium">{job.title}</h3>
-              <p className="text-gray-600">{job.description}</p>
+            <li key={job.id} className="border rounded p-4 hover:shadow">
+              <div className="flex justify-between items-center">
+                <div
+                  onClick={() => navigate(`/admin/jobs/${job.id}/edit`)}
+                  className="cursor-pointer"
+                >
+                  <h3 className="font-medium">{job.title}</h3>
+                  <p className="text-gray-600 truncate max-w-md">{job.description}</p>
+                </div>
+                <Button variant="ghost" onClick={() => onDelete(job.id)}>
+                  Delete
+                </Button>
+              </div>
             </li>
           ))}
         </ul>

--- a/frontend/src/lib/api/jobs.ts
+++ b/frontend/src/lib/api/jobs.ts
@@ -1,0 +1,46 @@
+import { Job } from '@/types/job'
+const API = import.meta.env.VITE_API_URL || ''
+
+function authHeaders() {
+  const token = localStorage.getItem('token')
+  return token ? { Authorization: `Bearer ${token}` } : {}
+}
+
+export async function fetchJobs(): Promise<Job[]> {
+  const res = await fetch(`${API}/api/admin/jobs/`, {
+    headers: { ...authHeaders() },
+  })
+  if (!res.ok) throw new Error(await res.text())
+  return res.json()
+}
+
+export async function createJob(data: { title: string; description: string }): Promise<Job> {
+  const res = await fetch(`${API}/api/admin/jobs/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify(data),
+  })
+  if (!res.ok) throw new Error(await res.text())
+  return res.json()
+}
+
+export async function updateJob(
+  id: string,
+  data: { title: string; description: string }
+): Promise<Job> {
+  const res = await fetch(`${API}/api/admin/jobs/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify(data),
+  })
+  if (!res.ok) throw new Error(await res.text())
+  return res.json()
+}
+
+export async function deleteJob(id: string): Promise<void> {
+  const res = await fetch(`${API}/api/admin/jobs/${id}`, {
+    method: 'DELETE',
+    headers: { ...authHeaders() },
+  })
+  if (!res.ok) throw new Error(await res.text())
+}

--- a/frontend/src/types/job.ts
+++ b/frontend/src/types/job.ts
@@ -1,8 +1,5 @@
 export interface Job {
-  id: number
+  id: string
   title: string
-  location: string
-  job_type: string
   description: string
-  requirements?: string
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,6 +9,10 @@ export default defineConfig({
       "@": path.resolve(__dirname, "src")
     }
   },
+  test: {
+    environment: 'jsdom',
+    setupFiles: './vitest.setup.ts'
+  },
   server: {
     host: true,        // слушаем 0.0.0.0, а не только localhost
     port: 5173,

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,0 +1,8 @@
+import { afterEach, expect } from 'vitest'
+import matchers from '@testing-library/jest-dom/matchers'
+expect.extend(matchers)
+import { cleanup } from '@testing-library/react'
+
+afterEach(() => {
+  cleanup()
+})


### PR DESCRIPTION
## Summary
- simplify `Job` model to UUID, title and description
- add Alembic migration for updated table
- adjust job schemas and admin routes
- update public and admin React components
- revise tests for new fields

## Testing
- `pytest -q`
- `npm run test --silent` *(fails: TypeError in vitest setup)*
- `npm run e2e --silent` *(Playwright config error)*

------
https://chatgpt.com/codex/tasks/task_e_686e62d5943083278bf5da8c88a49a09