### PR TITLE
Align frontend job routes with backend

### DIFF
--- a/frontend/src/components/JobList.tsx
+++ b/frontend/src/components/JobList.tsx
@@ -20,9 +20,8 @@ export default function JobList() {
   useEffect(() => {
     const fetchJobs = async () => {
       try {
-        const response = await axios.get<Job[]>(
-          "http://localhost:8000/api/jobs"
-        );
+        const API = import.meta.env.VITE_API_URL || ''
+        const response = await axios.get<Job[]>(`${API}/api/admin/jobs`)
         setJobs(response.data);
       } catch (_) {
         setError(t("jobs.error"));

--- a/frontend/src/components/admin/AdminJobForm.tsx
+++ b/frontend/src/components/admin/AdminJobForm.tsx
@@ -36,7 +36,7 @@ export default function AdminJobForm() {
       try {
         const API = import.meta.env.VITE_API_URL || ''
         const token = localStorage.getItem('token') || ''
-        const res = await fetch(`${API}/api/jobs/${jobId}`, {
+        const res = await fetch(`${API}/api/admin/jobs/${jobId}`, {
           headers: { Authorization: `Bearer ${token}` }
         })
         if (!res.ok) throw new Error(await res.text())
@@ -55,8 +55,8 @@ export default function AdminJobForm() {
       const API = import.meta.env.VITE_API_URL || ''
       const token = localStorage.getItem('token') || ''
       const url = editMode
-        ? `${API}/api/jobs/${jobId}`
-        : `${API}/api/jobs`
+        ? `${API}/api/admin/jobs/${jobId}`
+        : `${API}/api/admin/jobs`
       const method = editMode ? 'PUT' : 'POST'
       const res = await fetch(url, {
         method,


### PR DESCRIPTION
## Summary
- fix job fetching & editing paths to `/api/admin/jobs`
- use `VITE_API_URL` in JobList

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: 'httpx')*
- `npm run typecheck` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_686fa4dd16848327b5c6f06248164055