### PR TITLE
Change job routes to /api/jobs

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -51,8 +51,8 @@ app.add_middleware(
 # Include routers under /api
 app.include_router(health_router, prefix="/api", tags=["health"])
 app.include_router(auth_router,   prefix="/api", tags=["auth"])
-# Теперь вакансии доступны по /api/admin/jobs
-app.include_router(jobs_router,   prefix="/api/admin", tags=["admin", "jobs"])
+# Job routes are served under /api/jobs
+app.include_router(jobs_router,   prefix="/api", tags=["jobs"])
 app.include_router(forms_router,  prefix="/api", tags=["forms"])
 
 logger.info("Application routes configured")

--- a/frontend/src/components/JobList.tsx
+++ b/frontend/src/components/JobList.tsx
@@ -21,7 +21,7 @@ export default function JobList() {
     const fetchJobs = async () => {
       try {
         const API = import.meta.env.VITE_API_URL || ''
-        const response = await axios.get<Job[]>(`${API}/api/admin/jobs`)
+        const response = await axios.get<Job[]>(`${API}/api/jobs`)
         setJobs(response.data);
       } catch (_) {
         setError(t("jobs.error"));

--- a/frontend/src/components/admin/AdminJobForm.tsx
+++ b/frontend/src/components/admin/AdminJobForm.tsx
@@ -36,7 +36,7 @@ export default function AdminJobForm() {
       try {
         const API = import.meta.env.VITE_API_URL || ''
         const token = localStorage.getItem('token') || ''
-        const res = await fetch(`${API}/api/admin/jobs/${jobId}`, {
+        const res = await fetch(`${API}/api/jobs/${jobId}`, {
           headers: { Authorization: `Bearer ${token}` }
         })
         if (!res.ok) throw new Error(await res.text())
@@ -55,8 +55,8 @@ export default function AdminJobForm() {
       const API = import.meta.env.VITE_API_URL || ''
       const token = localStorage.getItem('token') || ''
       const url = editMode
-        ? `${API}/api/admin/jobs/${jobId}`
-        : `${API}/api/admin/jobs`
+        ? `${API}/api/jobs/${jobId}`
+        : `${API}/api/jobs`
       const method = editMode ? 'PUT' : 'POST'
       const res = await fetch(url, {
         method,

--- a/frontend/src/components/admin/AdminJobList.tsx
+++ b/frontend/src/components/admin/AdminJobList.tsx
@@ -24,7 +24,7 @@ export default function AdminJobList() {
         const API = import.meta.env.VITE_API_URL || ''
         const token = localStorage.getItem('token') || ''
 
-        const res = await fetch(`${API}/api/admin/jobs`, {
+        const res = await fetch(`${API}/api/jobs`, {
           headers: { Authorization: `Bearer ${token}` },
         })
 


### PR DESCRIPTION
## Summary
- mount job API under `/api`
- adjust frontend job API calls accordingly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install httpx` *(fails due to network access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686fc2a0907c8327a98340c7de1ef645