### PR TITLE
Add multilingual job translations

### DIFF
--- a/backend/alembic/versions/be8abb93c6f8_add_job_translations.py
+++ b/backend/alembic/versions/be8abb93c6f8_add_job_translations.py
@@ -1,0 +1,35 @@
+"""add job translations table
+
+Revision ID: be8abb93c6f8
+Revises: b6be0cd2fa57
+Create Date: 2025-07-10 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'be8abb93c6f8'
+down_revision: Union[str, None] = 'b6be0cd2fa57'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'job_translations',
+        sa.Column('job_id', sa.Integer(), nullable=False),
+        sa.Column('language', sa.String(), nullable=False),
+        sa.Column('title', sa.String(), nullable=False),
+        sa.Column('description', sa.String(), nullable=False),
+        sa.Column('requirements', sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(['job_id'], ['jobs.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('job_id', 'language')
+    )
+    op.create_index(op.f('ix_job_translations_job_id'), 'job_translations', ['job_id'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_job_translations_job_id'), table_name='job_translations')
+    op.drop_table('job_translations')

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1,5 +1,6 @@
 from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey
 from sqlalchemy.sql import func
+from sqlalchemy.orm import relationship
 from .database import Base
 from passlib.context import CryptContext
 import secrets
@@ -51,6 +52,25 @@ class Job(Base):
     requirements = Column(String, nullable=False)
     created_at = Column(DateTime, default=func.now())
     updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
+
+    translations = relationship(
+        "JobTranslation",
+        back_populates="job",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
+
+
+class JobTranslation(Base):
+    __tablename__ = "job_translations"
+
+    job_id = Column(Integer, ForeignKey("jobs.id", ondelete="CASCADE"), primary_key=True)
+    language = Column(String, primary_key=True)
+    title = Column(String, nullable=False)
+    description = Column(String, nullable=False)
+    requirements = Column(String, nullable=False)
+
+    job = relationship("Job", back_populates="translations")
 
 
 class ContactForm(Base):

--- a/backend/app/routes/jobs.py
+++ b/backend/app/routes/jobs.py
@@ -5,7 +5,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
 from app.db.database import get_db
-from app.db.models import Job, User
+from app.db.models import Job, JobTranslation, User
+from sqlalchemy.orm import selectinload
 from app.routes.auth import get_current_user
 from app.schemas.job import JobCreate, JobUpdate, JobResponse
 
@@ -24,13 +25,15 @@ async def admin_required(current_user: User = Depends(get_current_user)) -> User
 @router.get("", response_model=list[JobResponse])
 @router.get("/", response_model=list[JobResponse])
 async def list_jobs(db: AsyncSession = Depends(get_db)):
-    result = await db.execute(select(Job))
+    result = await db.execute(select(Job).options(selectinload(Job.translations)))
     return result.scalars().all()
 
 
 @router.get("/{job_id}", response_model=JobResponse)
 async def get_job(job_id: int, db: AsyncSession = Depends(get_db)):
-    result = await db.execute(select(Job).where(Job.id == job_id))
+    result = await db.execute(
+        select(Job).where(Job.id == job_id).options(selectinload(Job.translations))
+    )
     job = result.scalar_one_or_none()
     if not job:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
@@ -40,7 +43,11 @@ async def get_job(job_id: int, db: AsyncSession = Depends(get_db)):
 @router.post("", response_model=JobResponse, dependencies=[Depends(admin_required)])
 @router.post("/", response_model=JobResponse, dependencies=[Depends(admin_required)])
 async def create_job(job_in: JobCreate, db: AsyncSession = Depends(get_db)):
-    job = Job(**job_in.dict())
+    translations_data = job_in.translations
+    job_dict = job_in.dict(exclude={"translations"})
+    job = Job(**job_dict)
+    for tr in translations_data:
+        job.translations.append(JobTranslation(**tr.dict()))
     db.add(job)
     await db.commit()
     await db.refresh(job)
@@ -49,12 +56,19 @@ async def create_job(job_in: JobCreate, db: AsyncSession = Depends(get_db)):
 
 @router.put("/{job_id}", response_model=JobResponse, dependencies=[Depends(admin_required)])
 async def update_job(job_id: int, job_in: JobUpdate, db: AsyncSession = Depends(get_db)):
-    result = await db.execute(select(Job).where(Job.id == job_id))
+    result = await db.execute(
+        select(Job).where(Job.id == job_id).options(selectinload(Job.translations))
+    )
     job = result.scalar_one_or_none()
     if not job:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
-    for field, value in job_in.dict(exclude_unset=True).items():
+    update_data = job_in.dict(exclude_unset=True, exclude={"translations"})
+    for field, value in update_data.items():
         setattr(job, field, value)
+    if job_in.translations is not None:
+        job.translations.clear()
+        for tr in job_in.translations:
+            job.translations.append(JobTranslation(**tr.dict()))
     await db.commit()
     await db.refresh(job)
     return job

--- a/backend/app/schemas/job.py
+++ b/backend/app/schemas/job.py
@@ -3,6 +3,13 @@ from typing import Optional
 from pydantic import BaseModel
 
 
+class JobTranslation(BaseModel):
+    language: str
+    title: str
+    description: str
+    requirements: str
+
+
 class JobBase(BaseModel):
     title: str
     location: str
@@ -12,7 +19,7 @@ class JobBase(BaseModel):
 
 
 class JobCreate(JobBase):
-    pass
+    translations: list[JobTranslation] = []
 
 
 class JobUpdate(BaseModel):
@@ -21,12 +28,14 @@ class JobUpdate(BaseModel):
     job_type: Optional[str] = None
     description: Optional[str] = None
     requirements: Optional[str] = None
+    translations: Optional[list[JobTranslation]] = None
 
 
 class JobResponse(JobBase):
     id: int
     created_at: datetime
     updated_at: datetime
+    translations: list[JobTranslation] = []
 
     class Config:
         from_attributes = True

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -68,20 +68,42 @@ async def test_admin_job_crud(client: AsyncClient):
         "job_type": "Full-time",
         "description": "Develop software",
         "requirements": "Python",
+        "translations": [
+            {
+                "language": "fr",
+                "title": "Ing\u00e9nieur Logiciel",
+                "description": "D\u00e9velopper",
+                "requirements": "Python",
+            }
+        ],
     }
-    res = await client.post("/api/jobs/", json=job_data, headers=headers)
+    res = await client.post("/api/admin/jobs/", json=job_data, headers=headers)
     assert res.status_code == 200
     job_id = res.json()["id"]
 
     # Update job
-    res = await client.put(f"/api/jobs/{job_id}", json={"title": "Senior Engineer"}, headers=headers)
+    res = await client.put(
+        f"/api/admin/jobs/{job_id}",
+        json={
+            "title": "Senior Engineer",
+            "translations": [
+                {
+                    "language": "fr",
+                    "title": "Ing\u00e9nieur Principal",
+                    "description": "D\u00e9velopper",
+                    "requirements": "Python",
+                }
+            ],
+        },
+        headers=headers,
+    )
     assert res.status_code == 200
     assert res.json()["title"] == "Senior Engineer"
 
     # Delete job
-    res = await client.delete(f"/api/jobs/{job_id}", headers=headers)
+    res = await client.delete(f"/api/admin/jobs/{job_id}", headers=headers)
     assert res.status_code == 204
 
     # Ensure deletion
-    res = await client.get(f"/api/jobs/{job_id}")
+    res = await client.get(f"/api/admin/jobs/{job_id}")
     assert res.status_code == 404


### PR DESCRIPTION
## Summary
- support multilingual job content with `job_translations` table
- expose translations via API and schemas
- update CRUD operations for jobs
- create Alembic migration for job translations
- adjust job tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_686fc2a7c8688327b8ebc904a9ac6594