### PR TITLE
Add job deletion for admin UI

### DIFF
--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -107,3 +107,30 @@ async def test_admin_job_crud(client: AsyncClient):
     # Ensure deletion
     res = await client.get(f"/api/admin/jobs/{job_id}")
     assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_job_via_public_route(client: AsyncClient):
+    res = await client.post(
+        "/api/auth/login",
+        json={"email": "admin@example.com", "password": "password"},
+    )
+    token = res.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    job_data = {
+        "title": "QA Engineer",
+        "location": "Remote",
+        "job_type": "Full-time",
+        "description": "Test software",
+        "requirements": "QA",
+        "translations": [],
+    }
+    res = await client.post("/api/admin/jobs/", json=job_data, headers=headers)
+    job_id = res.json()["id"]
+
+    res = await client.delete(f"/api/jobs/{job_id}", headers=headers)
+    assert res.status_code == 204
+
+    res = await client.get(f"/api/jobs/{job_id}")
+    assert res.status_code == 404

--- a/frontend/src/components/admin/AdminJobForm.tsx
+++ b/frontend/src/components/admin/AdminJobForm.tsx
@@ -78,6 +78,27 @@ export default function AdminJobForm() {
     }
   }
 
+  const handleDelete = async () => {
+    if (!editMode || !jobId) return
+    if (!confirm('Delete this job?')) return
+    setSaving(true)
+    setError(null)
+    try {
+      const API = import.meta.env.VITE_API_URL || ''
+      const token = localStorage.getItem('token') || ''
+      const res = await fetch(`${API}/api/jobs/${jobId}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok && res.status !== 204) throw new Error(await res.text())
+      navigate('/admin/jobs')
+    } catch (err: any) {
+      setError(err.message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
   return (
     <div className="p-6 max-w-xl mx-auto">
       <h2 className="text-2xl font-semibold mb-4">{editMode ? 'Edit Job' : 'New Job'}</h2>
@@ -175,6 +196,11 @@ export default function AdminJobForm() {
           <Button variant="ghost" onClick={() => navigate('/admin/jobs')}>
             Cancel
           </Button>
+          {editMode && (
+            <Button variant="secondary" type="button" onClick={handleDelete}>
+              Delete
+            </Button>
+          )}
         </div>
       </form>
     </div>

--- a/frontend/src/components/admin/AdminJobList.tsx
+++ b/frontend/src/components/admin/AdminJobList.tsx
@@ -45,6 +45,26 @@ export default function AdminJobList() {
     load()
   }, [])
 
+  const handleDelete = async (id: number) => {
+    if (!confirm('Delete this job?')) return
+    try {
+      const API = import.meta.env.VITE_API_URL || ''
+      const token = localStorage.getItem('token') || ''
+      const res = await fetch(`${API}/api/jobs/${id}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (res.status === 204) {
+        setJobs((j) => j.filter((job) => job.id !== id))
+      } else {
+        const text = await res.text()
+        throw new Error(`Server responded ${res.status}: ${text || res.statusText}`)
+      }
+    } catch (err: any) {
+      setError(err.message)
+    }
+  }
+
   if (loading) {
     return <p>Loading…</p>
   }
@@ -70,11 +90,22 @@ export default function AdminJobList() {
           {jobs.map((job) => (
             <li
               key={job.id}
-              className="border rounded p-4 hover:shadow cursor-pointer"
+              className="border rounded p-4 hover:shadow flex justify-between"
               onClick={() => navigate(`${job.id}/edit`)}
             >
-              <h3 className="font-medium">{job.title}</h3>
-              <p className="text-gray-600">{job.description}</p>
+              <div className="cursor-pointer flex-1">
+                <h3 className="font-medium">{job.title}</h3>
+                <p className="text-gray-600">{job.description}</p>
+              </div>
+              <Button
+                variant="ghost"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  handleDelete(job.id)
+                }}
+              >
+                Delete
+              </Button>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary
- let admins delete jobs from the list and job form
- hit `/api/jobs/<id>` with auth token to delete
- remove deleted item from state
- add backend test for deletion via public route

## Testing
- `pre-commit run --files backend/tests/test_jobs.py frontend/src/components/admin/AdminJobForm.tsx frontend/src/components/admin/AdminJobList.tsx` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6870c1ef10608327aa12695308aa7707