### PR TITLE
Fix admin job API paths

### DIFF
--- a/frontend/src/components/admin/AdminJobForm.tsx
+++ b/frontend/src/components/admin/AdminJobForm.tsx
@@ -37,10 +37,9 @@ export default function AdminJobForm() {
       try {
         const API = import.meta.env.VITE_API_URL || ''
         const token = localStorage.getItem('token') || ''
-        const res = await fetch(
-          `${API}/api/admin/jobs/${jobId}`,
-          { headers: { Authorization: `Bearer ${token}` } }
-        )
+        const res = await fetch(`${API}/api/jobs/${jobId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        })
         if (!res.ok) throw new Error(await res.text())
         setJob(await res.json())
       } catch (err: any) {
@@ -57,8 +56,8 @@ export default function AdminJobForm() {
       const API = import.meta.env.VITE_API_URL || ''
       const token = localStorage.getItem('token') || ''
       const url = editMode
-        ? `${API}/api/admin/jobs/${jobId}`
-        : `${API}/api/admin/jobs`
+        ? `${API}/api/jobs/${jobId}`
+        : `${API}/api/jobs`
       const method = editMode ? 'PUT' : 'POST'
 
       const res = await fetch(url, {


### PR DESCRIPTION
## Summary
- switch admin job API endpoints from `/api/admin/jobs` to `/api/jobs`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6870d0c261cc8327ac8ba2efc8e7b92d