### PR TITLE
Fix job tests path

### DIFF
--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -77,13 +77,13 @@ async def test_admin_job_crud(client: AsyncClient):
             }
         ],
     }
-    res = await client.post("/api/admin/jobs/", json=job_data, headers=headers)
+    res = await client.post("/api/jobs/", json=job_data, headers=headers)
     assert res.status_code == 200
     job_id = res.json()["id"]
 
     # Update job
     res = await client.put(
-        f"/api/admin/jobs/{job_id}",
+        f"/api/jobs/{job_id}",
         json={
             "title": "Senior Engineer",
             "translations": [
@@ -101,11 +101,11 @@ async def test_admin_job_crud(client: AsyncClient):
     assert res.json()["title"] == "Senior Engineer"
 
     # Delete job
-    res = await client.delete(f"/api/admin/jobs/{job_id}", headers=headers)
+    res = await client.delete(f"/api/jobs/{job_id}", headers=headers)
     assert res.status_code == 204
 
     # Ensure deletion
-    res = await client.get(f"/api/admin/jobs/{job_id}")
+    res = await client.get(f"/api/jobs/{job_id}")
     assert res.status_code == 404
 
 
@@ -126,7 +126,7 @@ async def test_delete_job_via_public_route(client: AsyncClient):
         "requirements": "QA",
         "translations": [],
     }
-    res = await client.post("/api/admin/jobs/", json=job_data, headers=headers)
+    res = await client.post("/api/jobs/", json=job_data, headers=headers)
     job_id = res.json()["id"]
 
     res = await client.delete(f"/api/jobs/{job_id}", headers=headers)


### PR DESCRIPTION
## Summary
- update job tests to use `/api/jobs` endpoints

## Testing
- `pytest -q tests/test_jobs.py` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6870d0c7c45483278394274d58647fc7