### PR TITLE
Add location and type to job translations

### DIFF
--- a/backend/alembic/versions/d6b5e5c4b9fa_add_location_job_type_to_job_translation.py
+++ b/backend/alembic/versions/d6b5e5c4b9fa_add_location_job_type_to_job_translation.py
@@ -1,0 +1,28 @@
+"""add location and job_type to job translations
+
+Revision ID: d6b5e5c4b9fa
+Revises: be8abb93c6f8
+Create Date: 2025-08-01 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'd6b5e5c4b9fa'
+down_revision: Union[str, None] = 'be8abb93c6f8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('job_translations', sa.Column('location', sa.String(), nullable=False, server_default=''))
+    op.add_column('job_translations', sa.Column('job_type', sa.String(), nullable=False, server_default=''))
+    op.alter_column('job_translations', 'location', server_default=None)
+    op.alter_column('job_translations', 'job_type', server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column('job_translations', 'job_type')
+    op.drop_column('job_translations', 'location')

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -66,6 +66,8 @@ class JobTranslation(Base):
 
     job_id = Column(Integer, ForeignKey("jobs.id", ondelete="CASCADE"), primary_key=True)
     language = Column(String, primary_key=True)
+    location = Column(String, nullable=False)
+    job_type = Column(String, nullable=False)
     title = Column(String, nullable=False)
     description = Column(String, nullable=False)
     requirements = Column(String, nullable=False)

--- a/backend/app/schemas/job.py
+++ b/backend/app/schemas/job.py
@@ -5,6 +5,8 @@ from pydantic import BaseModel
 
 class JobTranslation(BaseModel):
     language: str
+    location: str
+    job_type: str
     title: str
     description: str
     requirements: str

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -71,6 +71,8 @@ async def test_admin_job_crud(client: AsyncClient):
         "translations": [
             {
                 "language": "fr",
+                "location": "Remote",
+                "job_type": "Full-time",
                 "title": "Ing\u00e9nieur Logiciel",
                 "description": "D\u00e9velopper",
                 "requirements": "Python",
@@ -89,6 +91,8 @@ async def test_admin_job_crud(client: AsyncClient):
             "translations": [
                 {
                     "language": "fr",
+                    "location": "Remote",
+                    "job_type": "Full-time",
                     "title": "Ing\u00e9nieur Principal",
                     "description": "D\u00e9velopper",
                     "requirements": "Python",


### PR DESCRIPTION
## Summary
- support `location` and `job_type` in job translations
- handle new fields in Pydantic schemas
- add Alembic migration for new columns
- update tests
- update admin job form serialization to include translations with these fields

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6870d0c6487883278384db5788f27bce