### PR TITLE
Fix job form API paths

### DIFF
--- a/frontend/src/components/admin/AdminJobForm.tsx
+++ b/frontend/src/components/admin/AdminJobForm.tsx
@@ -78,7 +78,7 @@ export default function AdminJobForm() {
       try {
         const API = import.meta.env.VITE_API_URL || ''
         const token = localStorage.getItem('token') || ''
-        const res = await fetch(`${API}/api/admin/jobs/${jobId}`, {
+        const res = await fetch(`${API}/api/jobs/${jobId}`, {
           headers: { Authorization: `Bearer ${token}` },
         })
         if (!res.ok) throw new Error(await res.text())
@@ -98,8 +98,8 @@ export default function AdminJobForm() {
       const API = import.meta.env.VITE_API_URL || ''
       const token = localStorage.getItem('token') || ''
       const url = editMode
-        ? `${API}/api/admin/jobs/${jobId}`
-        : `${API}/api/admin/jobs`
+        ? `${API}/api/jobs/${jobId}`
+        : `${API}/api/jobs`
       const method = editMode ? 'PUT' : 'POST'
 
       const res = await fetch(url, {
@@ -127,7 +127,7 @@ export default function AdminJobForm() {
     try {
       const API = import.meta.env.VITE_API_URL || ''
       const token = localStorage.getItem('token') || ''
-      const res = await fetch(`${API}/api/admin/jobs/${jobId}`, {
+      const res = await fetch(`${API}/api/jobs/${jobId}`, {
         method: 'DELETE',
         headers: { Authorization: `Bearer ${token}` },
       })


### PR DESCRIPTION
## Summary
- correct API endpoints in AdminJobForm to use existing `/api/jobs` routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_6870d58a71908327ae766232a661fb9e