### PR TITLE
Add scroll snap and parallax hooks

### DIFF
--- a/frontend/src/components/ParallaxSection.tsx
+++ b/frontend/src/components/ParallaxSection.tsx
@@ -1,0 +1,16 @@
+import { useRef, HTMLAttributes } from 'react';
+import useParallax from '../hooks/useParallax';
+
+export default function ParallaxSection(
+  props: HTMLAttributes<HTMLDivElement> & { speed?: number }
+) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  useParallax(ref, props.speed ?? 0.3);
+  return (
+    <section
+      ref={ref}
+      className={`relative overflow-hidden ${props.className ?? ''}`}
+      {...props}
+    />
+  );
+}

--- a/frontend/src/components/ScrollSection.tsx
+++ b/frontend/src/components/ScrollSection.tsx
@@ -1,18 +1,14 @@
-// src/components/ScrollSection.tsx
-import { useRef } from 'react';
-import useReveal from '../hooks/useReveal';
+import { useRef, HTMLAttributes } from 'react';
+import useScrollFade from '../hooks/useScrollFade';
 
-type Props = React.HTMLAttributes<HTMLDivElement>;
-
-export default function ScrollSection({ className = '', ...rest }: Props) {
+export default function ScrollSection(props: HTMLAttributes<HTMLDivElement>) {
   const ref = useRef<HTMLDivElement | null>(null);
-  useReveal(ref);                            // ✔️ типы без ошибки
-
+  useScrollFade(ref);
   return (
     <section
       ref={ref}
-      className={`section-transition ${className}`}
-      {...rest}
+      className={`snap-start ${props.className ?? ''}`}
+      {...props}
     />
   );
 }

--- a/frontend/src/hooks/useParallax.ts
+++ b/frontend/src/hooks/useParallax.ts
@@ -1,0 +1,17 @@
+import { RefObject, useEffect } from 'react';
+
+export default function useParallax(
+  ref: RefObject<HTMLElement | null>,
+  speed = 0.3
+) {
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const onScroll = () => {
+      const offset = window.pageYOffset;
+      el.style.transform = `translateY(${offset * speed}px)`;
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, [ref, speed]);
+}

--- a/frontend/src/hooks/useScrollFade.ts
+++ b/frontend/src/hooks/useScrollFade.ts
@@ -1,0 +1,22 @@
+import { RefObject, useEffect } from 'react';
+
+export default function useScrollFade(ref: RefObject<HTMLElement | null>) {
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const io = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          el.classList.add('animate-fade-up');
+          el.classList.remove('animate-fade-down');
+        } else {
+          el.classList.add('animate-fade-down');
+          el.classList.remove('animate-fade-up');
+        }
+      },
+      { threshold: 0.3 }
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [ref]);
+}

--- a/frontend/src/layouts/ClientLayout.tsx
+++ b/frontend/src/layouts/ClientLayout.tsx
@@ -17,7 +17,7 @@ export default function ClientLayout() {
       </div>
 
       {/* MAIN без глобального container — секции сами решают ширину */}
-      <main className="flex-1">
+      <main className="flex-1 snap-y snap-mandatory overflow-y-auto h-screen">
         <Outlet />
       </main>
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,22 +1,40 @@
 // frontend/src/pages/Home.tsx
-import Hero         from '../components/Hero'
-import About        from '../components/About'
-import Services     from '../components/Services'
-import JobList      from '../components/JobList'
+import Hero from '../components/Hero'
+import About from '../components/About'
+import Services from '../components/Services'
+import JobList from '../components/JobList'
 import Testimonials from '../components/Testimonials'
-import Contact      from '../components/Contact'
+import Contact from '../components/Contact'
 import MessengerContacts from '../components/MessengerContacts'
+import ScrollSection from '../components/ScrollSection'
+import ParallaxSection from '../components/ParallaxSection'
 
 export default function Home() {
   return (
     <>
       
-      <section id="hero"><Hero /></section>
-      <section id="about"><About /></section>
-      <section id="services"><Services /></section>
-      <section id="jobs"><JobList /></section>
-      <section id="testimonials"><Testimonials /></section>
-      <section id="contact"><Contact /></section>
+      <ScrollSection id="hero">
+        <Hero />
+      </ScrollSection>
+      <ParallaxSection
+        speed={0.15}
+        id="about"
+        className="snap-start h-[60vh] bg-[url('/images/about-bg.jpg')] bg-cover bg-center"
+      >
+        <About />
+      </ParallaxSection>
+      <ScrollSection id="services">
+        <Services />
+      </ScrollSection>
+      <ScrollSection id="jobs">
+        <JobList />
+      </ScrollSection>
+      <ScrollSection id="testimonials">
+        <Testimonials />
+      </ScrollSection>
+      <ScrollSection id="contact">
+        <Contact />
+      </ScrollSection>
       <MessengerContacts />
     </>
   )


### PR DESCRIPTION
## Summary
- implement scroll snapping in the client layout
- add `useScrollFade` hook and `ScrollSection` component
- implement parallax hook and wrapper
- update home page to use the new motion components

## Testing
- `pnpm -s run typecheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a24f0b9b88327bff052be9187e45d