### PR TITLE
Add translated location and type fields

### DIFF
--- a/backend/app/routes/jobs.py
+++ b/backend/app/routes/jobs.py
@@ -39,6 +39,8 @@ async def list_jobs(
                 setattr(job, f"title_{lang}", translation.title)
                 setattr(job, f"description_{lang}", translation.description)
                 setattr(job, f"requirements_{lang}", translation.requirements)
+                setattr(job, f"location_{lang}", translation.location)
+                setattr(job, f"job_type_{lang}", translation.job_type)
     return jobs
 
 

--- a/backend/app/schemas/job.py
+++ b/backend/app/schemas/job.py
@@ -47,6 +47,12 @@ class JobResponse(JobBase):
     requirements_en: Optional[str] = None
     requirements_ru: Optional[str] = None
     requirements_bg: Optional[str] = None
+    location_en: Optional[str] = None
+    location_ru: Optional[str] = None
+    location_bg: Optional[str] = None
+    job_type_en: Optional[str] = None
+    job_type_ru: Optional[str] = None
+    job_type_bg: Optional[str] = None
 
     class Config:
         from_attributes = True

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -174,3 +174,5 @@ async def test_list_jobs_with_language(client: AsyncClient):
     jobs = res.json()
     assert jobs[0]["title_ru"] == "Разработчик"
     assert jobs[0]["description_ru"] == "Писать код"
+    assert jobs[0]["location_ru"] == "Удаленно"
+    assert jobs[0]["job_type_ru"] == "Полная занятость"

--- a/frontend/src/components/JobList.tsx
+++ b/frontend/src/components/JobList.tsx
@@ -21,6 +21,12 @@ interface Job {
   requirements_en?: string
   requirements_ru?: string
   requirements_bg?: string
+  location_en?: string
+  location_ru?: string
+  location_bg?: string
+  job_type_en?: string
+  job_type_ru?: string
+  job_type_bg?: string
 }
 
 export default function JobList() {
@@ -76,6 +82,8 @@ export default function JobList() {
               const title = job[`title_${lang}` as keyof Job] ?? job.title
               const description = job[`description_${lang}` as keyof Job] ?? job.description
               const requirements = job[`requirements_${lang}` as keyof Job] ?? job.requirements
+              const location = job[`location_${lang}` as keyof Job] ?? job.location
+              const jobType = job[`job_type_${lang}` as keyof Job] ?? job.job_type
               return (
                 <div
                   key={job.id}
@@ -83,10 +91,10 @@ export default function JobList() {
                 >
                   <h3 className="text-xl font-semibold mb-2">{title}</h3>
                   <p className="text-gray-700 mb-1">
-                    <span className="font-medium">{t('nav.jobs')}:</span> {job.location}
+                    <span className="font-medium">{t('nav.jobs')}:</span> {location}
                   </p>
                   <p className="text-gray-700 mb-4">
-                    <span className="font-medium">{job.job_type}</span>
+                    <span className="font-medium">{jobType}</span>
                   </p>
                   <p className="text-gray-700 mb-4 line-clamp-3">{description}</p>
                   {requirements && (


### PR DESCRIPTION
## Summary
- include optional translated fields for location and job type in `JobResponse`
- expose those translations from the jobs list route
- update the frontend job list to display translated values
- test that translated location and job type are returned

## Testing
- `pytest -q backend/tests/test_jobs.py::test_list_jobs_with_language --maxfail=1 -q` *(fails: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_687a2dca3f088327a340865fc3c80806