### PR TITLE
Pass job title to contact form

### DIFF
--- a/frontend/src/components/Contact.tsx
+++ b/frontend/src/components/Contact.tsx
@@ -1,10 +1,12 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
+import { useLocation } from 'react-router-dom'
 import { useLanguage } from '../context/LanguageContext'
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
 
 export default function Contact() {
   const { t } = useLanguage()
+  const location = useLocation()
 
   const [form, setForm] = useState({
     fullName: '',
@@ -14,6 +16,14 @@ export default function Contact() {
     position: '',
     message: '',
   })
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search)
+    const title = params.get('position')
+    if (title) {
+      setForm((prev) => ({ ...prev, position: title }))
+    }
+  }, [location.search])
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value })

--- a/frontend/src/components/JobList.tsx
+++ b/frontend/src/components/JobList.tsx
@@ -1,6 +1,7 @@
 // frontend/src/components/JobList.tsx
 
 import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import axios from 'axios'
 import { useLanguage } from '../context/LanguageContext'
 
@@ -97,9 +98,12 @@ export default function JobList() {
                       <p className="mt-2 text-gray-600 whitespace-pre-line">{requirements}</p>
                     </details>
                   )}
-                  <button className="mt-2 px-4 py-2 bg-gray-900 text-white rounded hover:bg-gray-800 transition">
+                  <Link
+                    to={`/?position=${encodeURIComponent(title)}#contact`}
+                    className="mt-2 px-4 py-2 bg-gray-900 text-white rounded hover:bg-gray-800 transition"
+                  >
                     {t('hero.button')}
-                  </button>
+                  </Link>
                 </div>
               )
             })}


### PR DESCRIPTION
## Summary
- link vacancy 'Apply' button to contact section with title as URL param
- read `position` from query in `Contact` and set form initial value

## Testing
- `npx prettier --write frontend/src/components/Contact.tsx frontend/src/components/JobList.tsx`
- `npm run -s typecheck` *(fails: numerous TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a2ddb55e48327bdcfba946350f765