### PR TITLE
Update scroll animations and snap settings

### DIFF
--- a/frontend/src/components/MessengerContacts.tsx
+++ b/frontend/src/components/MessengerContacts.tsx
@@ -6,7 +6,7 @@ export default function MessengerContacts() {
   const phone = '+359 881 234 567' // contact phone number
 
   return (
-    <section id="messengers" className="py-10 bg-gray-100">
+    <section id="messengers" className="py-10 bg-gray-100 snap-start">
       <div className="container mx-auto px-6 text-center">
         <h2 className="text-2xl font-semibold mb-4">{t('messengers.title')}</h2>
         <div className="flex flex-col items-center space-y-2 text-lg">

--- a/frontend/src/components/ScrollSection.tsx
+++ b/frontend/src/components/ScrollSection.tsx
@@ -7,7 +7,7 @@ export default function ScrollSection(props: HTMLAttributes<HTMLDivElement>) {
   return (
     <section
       ref={ref}
-      className={`snap-start ${props.className ?? ''}`}
+      className={`opacity-0 transform translate-y-6 scale-[0.98] transition-all duration-700 ease-out snap-start ${props.className ?? ''}`}
       {...props}
     />
   );

--- a/frontend/src/hooks/useScrollFade.ts
+++ b/frontend/src/hooks/useScrollFade.ts
@@ -7,14 +7,12 @@ export default function useScrollFade(ref: RefObject<HTMLElement | null>) {
     const io = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
-          el.classList.add('animate-fade-up')
-          el.classList.remove('animate-fade-down')
+          el.classList.add('opacity-100', 'translate-y-0', 'scale-1')
         } else {
-          el.classList.add('animate-fade-down')
-          el.classList.remove('animate-fade-up')
+          el.classList.remove('opacity-100', 'translate-y-0', 'scale-1')
         }
       },
-      { threshold: 0.3, root: document.querySelector('main') }
+      { root: null, threshold: 0.3 }
     )
     io.observe(el)
     return () => io.disconnect()


### PR DESCRIPTION
## Summary
- refine `useScrollFade` hook options and behavior
- set default classes for `ScrollSection`
- ensure `MessengerContacts` is a snap point

## Testing
- `npm run format:check` *(fails: code style issues)*
- `npm run typecheck` *(fails: missing type declarations)*
- `pytest -q` *(fails: ModuleNotFoundError: 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_687a3c49fc7083278137640db17e6d2b