### PR TITLE
Update parallax hook

### DIFF
--- a/frontend/src/hooks/useParallax.ts
+++ b/frontend/src/hooks/useParallax.ts
@@ -4,13 +4,21 @@ export default function useParallax(ref: RefObject<HTMLElement | null>, speed = 
   useEffect(() => {
     const el = ref.current
     if (!el) return
-    const main = document.querySelector('main')
-    if (!main) return
-    const onScroll = () => {
-      const offset = main.scrollTop
+
+    let rafId = 0
+    const update = () => {
+      const offset = window.scrollY
       el.style.transform = `translateY(${offset * speed}px)`
+      rafId = 0
     }
-    main.addEventListener('scroll', onScroll, { passive: true })
-    return () => main.removeEventListener('scroll', onScroll)
+    const onScroll = () => {
+      if (!rafId) rafId = requestAnimationFrame(update)
+    }
+
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => {
+      window.removeEventListener('scroll', onScroll)
+      if (rafId) cancelAnimationFrame(rafId)
+    }
   }, [ref, speed])
 }


### PR DESCRIPTION
## Summary
- update parallax hook to read `window.scrollY`
- add requestAnimationFrame throttle and use window scroll listener

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npm --prefix frontend run typecheck` *(fails: cannot find module 'react-router-dom' et al)*

------
https://chatgpt.com/codex/tasks/task_e_687a3c4b9d7083279ca3822e7bc42c8c