### PR TITLE
Improve contact form UX

### DIFF
--- a/frontend/src/components/Contact.tsx
+++ b/frontend/src/components/Contact.tsx
@@ -8,6 +8,8 @@ export default function Contact() {
   const { t } = useLanguage()
   const location = useLocation()
 
+  const [isOpen, setIsOpen] = useState(false)
+
   const [form, setForm] = useState({
     fullName: '',
     country: '',
@@ -22,9 +24,17 @@ export default function Contact() {
     const title = params.get('position')
     if (title) {
       setForm((prev) => ({ ...prev, position: title }))
+      setIsOpen(true)
       document.getElementById('contact')?.scrollIntoView({ behavior: 'smooth' })
     }
   }, [location.search])
+
+  useEffect(() => {
+    if (location.hash === '#contact') {
+      setIsOpen(true)
+      document.getElementById('contact')?.scrollIntoView({ behavior: 'smooth' })
+    }
+  }, [location.hash])
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value })
@@ -57,90 +67,108 @@ export default function Contact() {
 
   return (
     <section id="contact" className="py-20 bg-gray-50">
-      <div className="container mx-auto px-6 max-w-lg">
-        <h2 className="text-3xl font-semibold text-gray-900 text-center mb-8">
-          {t('contact.title')}
-        </h2>
-        <form onSubmit={handleSubmit} className="space-y-6">
-          <div>
-            <label className="block text-gray-700 mb-1">{t('contact.fullName')}</label>
-            <input
-              type="text"
-              name="fullName"
-              value={form.fullName}
-              onChange={handleChange}
-              required
-              className="w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-gray-900"
-              placeholder={t('contact.fullName')}
-            />
-          </div>
-          <div>
-            <label className="block text-gray-700 mb-1">{t('contact.country')}</label>
-            <input
-              type="text"
-              name="country"
-              value={form.country}
-              onChange={handleChange}
-              required
-              className="w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-gray-900"
-              placeholder={t('contact.country')}
-            />
-          </div>
-          <div>
-            <label className="block text-gray-700 mb-1">{t('contact.email')}</label>
-            <input
-              type="email"
-              name="email"
-              value={form.email}
-              onChange={handleChange}
-              required
-              className="w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-gray-900"
-              placeholder={t('contact.email')}
-            />
-          </div>
-          <div>
-            <label className="block text-gray-700 mb-1">{t('contact.phone')}</label>
-            <input
-              type="tel"
-              name="phone"
-              value={form.phone}
-              onChange={handleChange}
-              required
-              className="w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-gray-900"
-              placeholder={t('contact.phone')}
-            />
-          </div>
-          <div>
-            <label className="block text-gray-700 mb-1">{t('contact.position')}</label>
-            <input
-              type="text"
-              name="position"
-              value={form.position}
-              onChange={handleChange}
-              className="w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-gray-900"
-              placeholder={t('contact.position')}
-            />
-          </div>
-          <div>
-            <label className="block text-gray-700 mb-1">{t('contact.message')}</label>
-            <textarea
-              name="message"
-              value={form.message}
-              onChange={handleChange}
-              rows={4}
-              className="w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-gray-900"
-              placeholder={t('contact.message')}
-            />
-          </div>
-          <div className="text-center">
-            <button
-              type="submit"
-              className="px-6 py-2 bg-gray-900 text-white rounded hover:bg-gray-800 transition"
+      <div className="container mx-auto px-6">
+        <details
+          id="contact-form"
+          open={isOpen}
+          onToggle={(e) => setIsOpen(e.currentTarget.open)}
+          className="group max-w-lg mx-auto bg-white border border-gray-200 rounded-xl shadow-lg transition-all duration-300 ease-out overflow-hidden"
+        >
+          <summary className="cursor-pointer select-none p-4 flex items-center justify-between">
+            <span className="text-xl font-heading font-semibold text-primary">
+              {t('contact.title')}
+            </span>
+            <svg
+              className="w-5 h-5 text-gray-500 transition-transform group-open:rotate-90"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
             >
-              {t('contact.submit')}
-            </button>
-          </div>
-        </form>
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </summary>
+          <form onSubmit={handleSubmit} className="p-6 pt-0 space-y-4">
+            <div>
+              <label className="block text-gray-700 mb-1">{t('contact.fullName')}</label>
+              <input
+                type="text"
+                name="fullName"
+                value={form.fullName}
+                onChange={handleChange}
+                required
+                className="w-full px-4 py-2 border border-gray-300 rounded-md bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-900"
+                placeholder={t('contact.fullName')}
+              />
+            </div>
+            <div>
+              <label className="block text-gray-700 mb-1">{t('contact.country')}</label>
+              <input
+                type="text"
+                name="country"
+                value={form.country}
+                onChange={handleChange}
+                required
+                className="w-full px-4 py-2 border border-gray-300 rounded-md bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-900"
+                placeholder={t('contact.country')}
+              />
+            </div>
+            <div>
+              <label className="block text-gray-700 mb-1">{t('contact.email')}</label>
+              <input
+                type="email"
+                name="email"
+                value={form.email}
+                onChange={handleChange}
+                required
+                className="w-full px-4 py-2 border border-gray-300 rounded-md bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-900"
+                placeholder={t('contact.email')}
+              />
+            </div>
+            <div>
+              <label className="block text-gray-700 mb-1">{t('contact.phone')}</label>
+              <input
+                type="tel"
+                name="phone"
+                value={form.phone}
+                onChange={handleChange}
+                required
+                className="w-full px-4 py-2 border border-gray-300 rounded-md bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-900"
+                placeholder={t('contact.phone')}
+              />
+            </div>
+            <div>
+              <label className="block text-gray-700 mb-1">{t('contact.position')}</label>
+              <input
+                type="text"
+                name="position"
+                value={form.position}
+                onChange={handleChange}
+                className="w-full px-4 py-2 border border-gray-300 rounded-md bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-900"
+                placeholder={t('contact.position')}
+              />
+            </div>
+            <div>
+              <label className="block text-gray-700 mb-1">{t('contact.message')}</label>
+              <textarea
+                name="message"
+                value={form.message}
+                onChange={handleChange}
+                rows={4}
+                className="w-full px-4 py-2 border border-gray-300 rounded-md bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-900"
+                placeholder={t('contact.message')}
+              />
+            </div>
+            <div className="text-center">
+              <button
+                type="submit"
+                className="inline-block px-6 py-2 bg-accentGreen text-white font-medium rounded-full hover:bg-accentGreen/90 transition-shadow"
+              >
+                {t('contact.submit')}
+              </button>
+            </div>
+          </form>
+        </details>
       </div>
     </section>
   )

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,18 +1,26 @@
-import { useState } from 'react';
-import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
-import { useLanguage } from '../context/LanguageContext';
-import LanguageSwitcher from './LanguageSwitcher';
-import logo from '../assets/logo-icon.png';
+import { useState } from 'react'
+import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline'
+import { useLanguage } from '../context/LanguageContext'
+import LanguageSwitcher from './LanguageSwitcher'
+import logo from '../assets/logo-icon.png'
 
 export default function Navbar() {
-  const { t } = useLanguage();
-  const [open, setOpen] = useState(false);
+  const { t } = useLanguage()
+  const [open, setOpen] = useState(false)
+
+  const handleNavClick = (href: string) => {
+    if (href === '#contact') {
+      const details = document.getElementById('contact-form') as HTMLDetailsElement | null
+      if (details) details.open = true
+      document.getElementById('contact')?.scrollIntoView({ behavior: 'smooth' })
+    }
+  }
 
   const nav = [
     { href: '#hero', label: t('nav.home') as string },
     { href: '#jobs', label: t('nav.jobs') as string },
     { href: '#contact', label: t('nav.contact') as string },
-  ];
+  ]
 
   return (
     <header className="sticky top-0 z-50 bg-white/80 backdrop-blur border-b border-gray-200 shadow-sm">
@@ -31,6 +39,7 @@ export default function Navbar() {
             <a
               key={href}
               href={href}
+              onClick={() => handleNavClick(href)}
               className="text-lg font-medium text-primary hover:text-accentRed transition-colors"
             >
               {label}
@@ -60,7 +69,10 @@ export default function Navbar() {
               <a
                 key={href}
                 href={href}
-                onClick={() => setOpen(false)}
+                onClick={() => {
+                  setOpen(false)
+                  handleNavClick(href)
+                }}
                 className="text-lg text-primary hover:text-accentRed"
               >
                 {label}
@@ -71,5 +83,5 @@ export default function Navbar() {
         </div>
       )}
     </header>
-  );
+  )
 }


### PR DESCRIPTION
## Summary
- collapse contact form inside `<details>`
- auto-open and scroll when contacting from menu or Apply button
- style form fields for compact layout

## Testing
- `npm run typecheck` *(fails: cannot find module 'react')*


------
https://chatgpt.com/codex/tasks/task_e_687a40fbb7808327b5b266b17d8b06c1