### PR TITLE
Add chat section with modal

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,7 @@ import Services from './components/Services'
 import JobList from './components/JobList'
 import Testimonials from './components/Testimonials'
 import Contact from './components/Contact'
-import MessengerContacts from './components/MessengerContacts'
+import Chat from './components/Chat'
 import Footer from './components/Footer'
 
 export default function App() {
@@ -25,7 +25,7 @@ export default function App() {
           <JobList />
           <Testimonials />
           <Contact />
-          <MessengerContacts />
+          <Chat />
         </main>
 
         <Footer />

--- a/frontend/src/assets/icons/viber.svg
+++ b/frontend/src/assets/icons/viber.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <circle cx="12" cy="12" r="11" fill="#665cac"/>
+  <path d="M8 7h8v2H8zM8 11h6v2H8z" fill="#fff"/>
+</svg>

--- a/frontend/src/assets/icons/whatsapp.svg
+++ b/frontend/src/assets/icons/whatsapp.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <circle cx="12" cy="12" r="11" fill="#43d854"/>
+  <path d="M9 7h2v2H9zM13 11h2v2h-2z" fill="#fff"/>
+</svg>

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -1,0 +1,37 @@
+import { useLanguage } from '../context/LanguageContext'
+import viberIcon from '../assets/icons/viber.svg'
+import whatsappIcon from '../assets/icons/whatsapp.svg'
+
+export default function Chat() {
+  const { t } = useLanguage()
+  const phone = '+359 881 234 567'
+  return (
+    <section id="messengers" className="py-10 bg-gray-100 hidden lg:block">
+      <div className="container mx-auto px-6 text-center">
+        <h2 className="text-2xl font-semibold mb-6">{t('messengers.title')}</h2>
+        <div className="mx-auto grid max-w-md grid-cols-1 gap-4 sm:grid-cols-2">
+          <a
+            href={`viber://chat?number=${phone.replace(/\s+/g, '')}`}
+            className="flex items-center gap-4 p-4 bg-white rounded-lg hover:shadow-lg hover:-translate-y-1 transition-all duration-200"
+          >
+            <img src={viberIcon} alt="Viber" className="h-8 w-8" />
+            <div className="text-left">
+              <p className="font-medium">{t('messengers.viber')}</p>
+              <p className="text-gray-700">{phone}</p>
+            </div>
+          </a>
+          <a
+            href={`https://wa.me/${phone.replace(/\D/g, '')}`}
+            className="flex items-center gap-4 p-4 bg-white rounded-lg hover:shadow-lg hover:-translate-y-1 transition-all duration-200"
+          >
+            <img src={whatsappIcon} alt="WhatsApp" className="h-8 w-8" />
+            <div className="text-left">
+              <p className="font-medium">{t('messengers.whatsapp')}</p>
+              <p className="text-gray-700">{phone}</p>
+            </div>
+          </a>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/ChatModal.tsx
+++ b/frontend/src/components/ChatModal.tsx
@@ -1,0 +1,52 @@
+import { useLanguage } from '../context/LanguageContext'
+import viberIcon from '../assets/icons/viber.svg'
+import whatsappIcon from '../assets/icons/whatsapp.svg'
+
+interface ChatModalProps {
+  open: boolean
+  onClose: () => void
+}
+
+export default function ChatModal({ open, onClose }: ChatModalProps) {
+  const { t } = useLanguage()
+  const phone = '+359 881 234 567'
+  if (!open) return null
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 lg:hidden">
+      <div className="relative bg-white rounded-lg p-6 w-11/12 max-w-sm">
+        <button
+          onClick={onClose}
+          className="absolute right-3 top-3 text-gray-500 hover:text-gray-700"
+          aria-label="Close"
+        >
+          ×
+        </button>
+        <h2 className="text-xl font-semibold mb-4 text-center">
+          {t('messengers.title')}
+        </h2>
+        <div className="grid gap-4">
+          <a
+            href={`viber://chat?number=${phone.replace(/\s+/g, '')}`}
+            className="flex items-center gap-4 p-4 bg-gray-50 rounded-lg hover:shadow-lg hover:-translate-y-1 transition-all duration-200"
+          >
+            <img src={viberIcon} alt="Viber" className="h-8 w-8" />
+            <div className="text-left">
+              <p className="font-medium">{t('messengers.viber')}</p>
+              <p className="text-gray-700">{phone}</p>
+            </div>
+          </a>
+          <a
+            href={`https://wa.me/${phone.replace(/\D/g, '')}`}
+            className="flex items-center gap-4 p-4 bg-gray-50 rounded-lg hover:shadow-lg hover:-translate-y-1 transition-all duration-200"
+          >
+            <img src={whatsappIcon} alt="WhatsApp" className="h-8 w-8" />
+            <div className="text-left">
+              <p className="font-medium">{t('messengers.whatsapp')}</p>
+              <p className="text-gray-700">{phone}</p>
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/layouts/ClientLayout.tsx
+++ b/frontend/src/layouts/ClientLayout.tsx
@@ -1,10 +1,14 @@
 // frontend/src/layouts/ClientLayout.tsx
+import { useState } from 'react'
 import { Outlet } from 'react-router-dom'
 import Navbar from '../components/Navbar'
 import { ThemeToggle } from '../components/ui/ThemeToggle'
+import ChatModal from '../components/ChatModal'
+import { MessageSquare } from 'lucide-react'
 
 export default function ClientLayout() {
   const year = new Date().getFullYear()
+  const [chatOpen, setChatOpen] = useState(false)
 
   return (
     <div className="min-h-screen flex flex-col bg-gray-50 dark:bg-gray-900 transition-colors">
@@ -27,6 +31,18 @@ export default function ClientLayout() {
           © {year} HR Agency. All rights reserved.
         </div>
       </footer>
+
+      {/* Floating chat button visible only on small screens */}
+      <button
+        onClick={() => setChatOpen(true)}
+        className="lg:hidden fixed bottom-6 right-6 z-40 rounded-full bg-accentGreen p-4 text-white shadow-lg"
+        aria-label="Open chat options"
+      >
+        <MessageSquare className="h-6 w-6" />
+      </button>
+
+      {/* Modal with messenger links */}
+      <ChatModal open={chatOpen} onClose={() => setChatOpen(false)} />
     </div>
   )
 }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -5,7 +5,7 @@ import Services from '../components/Services'
 import JobList from '../components/JobList'
 import Testimonials from '../components/Testimonials'
 import Contact from '../components/Contact'
-import MessengerContacts from '../components/MessengerContacts'
+import Chat from '../components/Chat'
 import ScrollSection from '../components/ScrollSection'
 import ParallaxSection from '../components/ParallaxSection'
 
@@ -35,7 +35,7 @@ export default function Home() {
       <ScrollSection id="contact">
         <Contact />
       </ScrollSection>
-      <MessengerContacts />
+      <Chat />
     </>
   )
 }


### PR DESCRIPTION
## Summary
- add Chat component with messenger cards and icons
- include Chat modal with floating button in `ClientLayout`
- use new Chat component in Home and App pages
- add placeholder SVG icons for Viber and WhatsApp

## Testing
- `npm run format:check` *(fails: code style issues found)*
- `npm run typecheck` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_687a5487ff8483278fca6feb62c356e3