### PR TITLE
Fix scroll snapping behavior

### DIFF
--- a/frontend/src/components/MessengerContacts.tsx
+++ b/frontend/src/components/MessengerContacts.tsx
@@ -6,7 +6,7 @@ export default function MessengerContacts() {
   const phone = '+359 881 234 567' // contact phone number
 
   return (
-    <section id="messengers" className="py-10 bg-gray-100 snap-start">
+    <section id="messengers" className="py-10 bg-gray-100">
       <div className="container mx-auto px-6 text-center">
         <h2 className="text-2xl font-semibold mb-4">{t('messengers.title')}</h2>
         <div className="flex flex-col items-center space-y-2 text-lg">

--- a/frontend/src/components/ScrollSection.tsx
+++ b/frontend/src/components/ScrollSection.tsx
@@ -7,7 +7,7 @@ export default function ScrollSection(props: HTMLAttributes<HTMLDivElement>) {
   return (
     <section
       ref={ref}
-      className={`opacity-0 transform translate-y-6 scale-[0.98] transition-all duration-700 ease-out snap-start ${props.className ?? ''}`}
+      className={`opacity-0 transform translate-y-6 scale-[0.98] transition-all duration-700 ease-out ${props.className ?? ''}`}
       {...props}
     />
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7,7 +7,7 @@
 }
 
 html {
-  scroll-snap-type: y mandatory;
+  /* scroll-snap-type: y mandatory; */
   scroll-behavior: smooth;
 }
 
@@ -16,5 +16,5 @@ body {
 }
 
 section {
-  scroll-snap-align: start;
+  /* scroll-snap-align: start; */
 }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -19,7 +19,7 @@ export default function Home() {
       <ParallaxSection
         speed={0.15}
         id="about"
-        className="snap-start h-[60vh] bg-[url('/images/about-bg.jpg')] bg-cover bg-center"
+        className="h-[60vh] bg-[url('/images/about-bg.jpg')] bg-cover bg-center"
       >
         <About />
       </ParallaxSection>


### PR DESCRIPTION
## Summary
- comment out scroll snapping CSS
- remove `snap-start` class from ScrollSection, MessengerContacts and Home page

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/@vitejs%2Fplugin-react: Forbidden)*
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement aiosqlite==0.21.0)*

------
https://chatgpt.com/codex/tasks/task_e_687a5862193c8327848b4680e27433e2