### PR TITLE
Add base typography styles for headings and text

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -15,3 +15,19 @@ html {
 body {
   scroll-padding-top: var(--navbar-height);
 }
+
+/* Default typography styles */
+@layer base {
+  h2 {
+    @apply font-heading text-2xl;
+  }
+  h3 {
+    @apply font-heading text-xl;
+  }
+  p {
+    @apply font-sans text-base;
+  }
+  span {
+    @apply font-sans text-base;
+  }
+}


### PR DESCRIPTION
## Summary
- apply default Tailwind classes to `h2`, `h3`, `p` and `span`

## Testing
- `npm run typecheck` *(fails: Cannot find module 'react-router-dom')*
- `npm run format:check` *(fails: code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_687de903463c83279b8e44a36a514fa2