### PR TITLE
Restyle messenger contacts

### DIFF
--- a/frontend/src/components/MessengerContacts.tsx
+++ b/frontend/src/components/MessengerContacts.tsx
@@ -1,5 +1,7 @@
 // frontend/src/components/MessengerContacts.tsx
 import { useLanguage } from '../context/LanguageContext'
+import viberIcon from '../assets/icons/viber.svg'
+import whatsappIcon from '../assets/icons/whatsapp.svg'
 
 export default function MessengerContacts() {
   const { t } = useLanguage()
@@ -8,26 +10,26 @@ export default function MessengerContacts() {
   return (
     <section id="messengers" className="py-10 bg-gray-100">
       <div className="container mx-auto px-6 text-center">
-        <h2 className="text-2xl font-semibold mb-4">{t('messengers.title')}</h2>
-        <div className="flex flex-col items-center space-y-2 text-lg">
-          <div>
-            <span className="font-medium mr-1">{t('messengers.viber')}:</span>
-            <a
-              href={`viber://chat?number=${phone.replace(/\s+/g, '')}`}
-              className="text-gray-900 hover:underline"
-            >
-              {phone}
-            </a>
-          </div>
-          <div>
-            <span className="font-medium mr-1">{t('messengers.whatsapp')}:</span>
-            <a
-              href={`https://wa.me/${phone.replace(/\D/g, '')}`}
-              className="text-gray-900 hover:underline"
-            >
-              {phone}
-            </a>
-          </div>
+        <h2 className="text-2xl font-heading font-semibold text-primary mb-6">
+          {t('messengers.title')}
+        </h2>
+        <div className="flex justify-center gap-4">
+          <a
+            href={`viber://chat?number=${phone.replace(/\s+/g, '')}`}
+            className="bg-white rounded-lg shadow-md p-4 w-40 text-center hover:shadow-lg transition block"
+          >
+            <img src={viberIcon} alt="Viber" className="h-8 w-8 mx-auto mb-2" />
+            <p className="font-heading text-primary">{t('messengers.viber')}</p>
+            <p className="font-sans text-sm text-primary">{phone}</p>
+          </a>
+          <a
+            href={`https://wa.me/${phone.replace(/\D/g, '')}`}
+            className="bg-white rounded-lg shadow-md p-4 w-40 text-center hover:shadow-lg transition block"
+          >
+            <img src={whatsappIcon} alt="WhatsApp" className="h-8 w-8 mx-auto mb-2" />
+            <p className="font-heading text-primary">{t('messengers.whatsapp')}</p>
+            <p className="font-sans text-sm text-primary">{phone}</p>
+          </a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- redesign MessengerContacts cards with icons
- use brand fonts and colors for the messenger list

## Testing
- `npm --prefix frontend run typecheck` *(fails: Cannot find module 'react-router-dom')*
- `npx prettier -w frontend/src/components/MessengerContacts.tsx`

------
https://chatgpt.com/codex/tasks/task_e_687de92196448327a4f932a953d67f2a