### PR TITLE
Unify heading fonts and text styles

### DIFF
--- a/frontend/src/components/About.tsx
+++ b/frontend/src/components/About.tsx
@@ -7,10 +7,10 @@ export default function About() {
   return (
     <div id="about" className="py-20 bg-white">
       <div className="container mx-auto px-6">
-        <h2 className="text-3xl font-semibold text-gray-900 mb-4">
+        <h2 className="font-heading text-3xl md:text-4xl text-primary text-center mb-8">
           {t("about.title")}
         </h2>
-        <p className="text-gray-600 leading-relaxed">
+        <p className="font-sans text-base text-primary leading-relaxed">
           {t("about.text")}
         </p>
       </div>

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -8,7 +8,9 @@ export default function Chat() {
   return (
     <section id="messengers" className="py-10 bg-gray-100 hidden lg:block">
       <div className="container mx-auto px-6 text-center">
-        <h2 className="text-2xl font-semibold mb-6">{t('messengers.title')}</h2>
+        <h2 className="font-heading text-3xl md:text-4xl text-primary text-center mb-8">
+          {t('messengers.title')}
+        </h2>
         <div className="mx-auto grid max-w-md grid-cols-1 gap-4 sm:grid-cols-2">
           <a
             href={`viber://chat?number=${phone.replace(/\s+/g, '')}`}
@@ -16,8 +18,10 @@ export default function Chat() {
           >
             <img src={viberIcon} alt="Viber" className="h-8 w-8" />
             <div className="text-left">
-              <p className="font-medium">{t('messengers.viber')}</p>
-              <p className="text-gray-700">{phone}</p>
+              <p className="font-sans text-base text-primary font-medium">
+                {t('messengers.viber')}
+              </p>
+              <p className="font-sans text-base text-primary">{phone}</p>
             </div>
           </a>
           <a
@@ -26,8 +30,10 @@ export default function Chat() {
           >
             <img src={whatsappIcon} alt="WhatsApp" className="h-8 w-8" />
             <div className="text-left">
-              <p className="font-medium">{t('messengers.whatsapp')}</p>
-              <p className="text-gray-700">{phone}</p>
+              <p className="font-sans text-base text-primary font-medium">
+                {t('messengers.whatsapp')}
+              </p>
+              <p className="font-sans text-base text-primary">{phone}</p>
             </div>
           </a>
         </div>

--- a/frontend/src/components/ChatModal.tsx
+++ b/frontend/src/components/ChatModal.tsx
@@ -21,7 +21,7 @@ export default function ChatModal({ open, onClose }: ChatModalProps) {
         >
           ×
         </button>
-        <h2 className="text-xl font-semibold mb-4 text-center">
+        <h2 className="font-heading text-3xl md:text-4xl text-primary text-center mb-8">
           {t('messengers.title')}
         </h2>
         <div className="grid gap-4">
@@ -31,8 +31,8 @@ export default function ChatModal({ open, onClose }: ChatModalProps) {
           >
             <img src={viberIcon} alt="Viber" className="h-8 w-8" />
             <div className="text-left">
-              <p className="font-medium">{t('messengers.viber')}</p>
-              <p className="text-gray-700">{phone}</p>
+              <p className="font-sans text-base text-primary font-medium">{t('messengers.viber')}</p>
+              <p className="font-sans text-base text-primary">{phone}</p>
             </div>
           </a>
           <a
@@ -41,8 +41,8 @@ export default function ChatModal({ open, onClose }: ChatModalProps) {
           >
             <img src={whatsappIcon} alt="WhatsApp" className="h-8 w-8" />
             <div className="text-left">
-              <p className="font-medium">{t('messengers.whatsapp')}</p>
-              <p className="text-gray-700">{phone}</p>
+              <p className="font-sans text-base text-primary font-medium">{t('messengers.whatsapp')}</p>
+              <p className="font-sans text-base text-primary">{phone}</p>
             </div>
           </a>
         </div>

--- a/frontend/src/components/Contact.tsx
+++ b/frontend/src/components/Contact.tsx
@@ -83,7 +83,7 @@ export default function Contact() {
           className="group max-w-lg mx-auto bg-white border border-gray-200 rounded-xl shadow-lg transition-all duration-300 ease-out overflow-hidden"
         >
           <summary className="cursor-pointer select-none p-4 flex items-center justify-between">
-            <span className="text-xl font-heading font-semibold text-primary">
+            <span className="font-heading text-2xl text-primary">
               {t('contact.title')}
             </span>
             <svg

--- a/frontend/src/components/FeedbackModal.tsx
+++ b/frontend/src/components/FeedbackModal.tsx
@@ -13,8 +13,12 @@ export default function FeedbackModal({ title, message, onClose }: FeedbackModal
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center transition-opacity duration-200 ease-out z-50">
       <div className="bg-white rounded-xl p-6 max-w-sm mx-auto shadow-lg">
-        {title && <h2 className="text-xl font-semibold mb-2 text-primary">{title}</h2>}
-        <p className="text-lg font-medium text-primary">{message}</p>
+        {title && (
+          <h2 className="font-heading text-3xl md:text-4xl text-primary text-center mb-8">
+            {title}
+          </h2>
+        )}
+        <p className="font-sans text-base text-primary font-medium">{message}</p>
         <button
           onClick={onClose}
           className="mt-4 px-6 py-2 bg-accentGreen text-white rounded-full hover:bg-accentGreen/90 transition"

--- a/frontend/src/components/Hero.tsx
+++ b/frontend/src/components/Hero.tsx
@@ -26,7 +26,7 @@ export default function Hero() {
         <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-extrabold text-white leading-tight">
           {t("hero.headline")}
         </h1>
-        <p className="mt-4 text-md sm:text-lg md:text-xl text-gray-200 max-w-2xl">
+        <p className="mt-4 font-sans text-base text-primary max-w-2xl">
           {t("hero.subtext")}
         </p>
         <a

--- a/frontend/src/components/JobList.tsx
+++ b/frontend/src/components/JobList.tsx
@@ -55,7 +55,7 @@ export default function JobList() {
     return (
       <div id="jobs" className="py-20 bg-gray-100">
         <div className="container mx-auto px-6 text-center">
-          <span className="text-lg text-gray-500">{t('jobs.loading')}</span>
+          <span className="font-sans text-base text-primary">{t('jobs.loading')}</span>
         </div>
       </div>
     )
@@ -65,7 +65,7 @@ export default function JobList() {
     return (
       <div id="jobs" className="py-20 bg-gray-100">
         <div className="container mx-auto px-6 text-center">
-          <span className="text-lg text-red-500">{error}</span>
+          <span className="font-sans text-base text-primary">{error}</span>
         </div>
       </div>
     )
@@ -74,7 +74,7 @@ export default function JobList() {
   return (
     <div id="jobs" className="py-20 bg-gray-100">
       <div className="container mx-auto px-6">
-        <h2 className="text-3xl font-heading font-extrabold text-primary text-center mb-8">
+        <h2 className="font-heading text-3xl md:text-4xl text-primary text-center mb-8">
           {t('jobs.title')}
         </h2>
 
@@ -103,10 +103,10 @@ export default function JobList() {
                 >
                   <summary className="cursor-pointer select-none p-4 flex flex-col sm:flex-row sm:justify-between sm:items-center">
                     <div>
-                      <h3 className="text-lg font-heading font-semibold text-primary group-open:mb-1">
+                      <h3 className="font-heading text-2xl text-primary mb-2 group-open:mb-1">
                         {title}
                       </h3>
-                      <p className="text-sm text-gray-700">
+                      <p className="font-sans text-base text-primary">
                         {location} • {jobType}
                       </p>
                     </div>
@@ -126,14 +126,14 @@ export default function JobList() {
                     </svg>
                   </summary>
 
-                  <div className="px-4 pb-4 space-y-4 text-gray-700">
-                    <p className="whitespace-pre-line">{description}</p>
+                  <div className="px-4 pb-4 space-y-4 text-primary">
+                    <p className="font-sans text-base whitespace-pre-line text-primary">{description}</p>
                     {requirements && (
                       <div>
                         <h4 className="font-medium text-primary">
                           {t('jobs.requirements')}
                         </h4>
-                        <p className="whitespace-pre-line">{requirements}</p>
+                        <p className="font-sans text-base text-primary whitespace-pre-line">{requirements}</p>
                       </div>
                     )}
                     <button
@@ -152,7 +152,7 @@ export default function JobList() {
             })}
           </div>
         ) : (
-          <p className="text-center text-gray-500">{t('jobs.noJobs')}</p>
+          <p className="font-sans text-base text-primary text-center">{t('jobs.noJobs')}</p>
         )}
       </div>
     </div>

--- a/frontend/src/components/MessengerContacts.tsx
+++ b/frontend/src/components/MessengerContacts.tsx
@@ -10,7 +10,7 @@ export default function MessengerContacts() {
   return (
     <section id="messengers" className="py-10 bg-gray-100">
       <div className="container mx-auto px-6 text-center">
-        <h2 className="text-2xl font-heading font-semibold text-primary mb-6">
+        <h2 className="font-heading text-3xl md:text-4xl text-primary text-center mb-8">
           {t('messengers.title')}
         </h2>
         <div className="flex justify-center gap-4">
@@ -19,16 +19,16 @@ export default function MessengerContacts() {
             className="bg-white rounded-lg shadow-md p-4 w-40 text-center hover:shadow-lg transition block"
           >
             <img src={viberIcon} alt="Viber" className="h-8 w-8 mx-auto mb-2" />
-            <p className="font-heading text-primary">{t('messengers.viber')}</p>
-            <p className="font-sans text-sm text-primary">{phone}</p>
+            <p className="font-heading text-2xl text-primary mb-2">{t('messengers.viber')}</p>
+            <p className="font-sans text-base text-primary">{phone}</p>
           </a>
           <a
             href={`https://wa.me/${phone.replace(/\D/g, '')}`}
             className="bg-white rounded-lg shadow-md p-4 w-40 text-center hover:shadow-lg transition block"
           >
             <img src={whatsappIcon} alt="WhatsApp" className="h-8 w-8 mx-auto mb-2" />
-            <p className="font-heading text-primary">{t('messengers.whatsapp')}</p>
-            <p className="font-sans text-sm text-primary">{phone}</p>
+            <p className="font-heading text-2xl text-primary mb-2">{t('messengers.whatsapp')}</p>
+            <p className="font-sans text-base text-primary">{phone}</p>
           </a>
         </div>
       </div>

--- a/frontend/src/components/Services.tsx
+++ b/frontend/src/components/Services.tsx
@@ -18,7 +18,7 @@ export default function Services() {
   return (
     <div id="services" className="py-20 bg-gray-50">
       <div className="container mx-auto px-6 text-center mb-12">
-        <h2 className="text-3xl font-semibold text-gray-900">
+        <h2 className="font-heading text-3xl md:text-4xl text-primary text-center mb-8">
           {t("services.title")}
         </h2>
       </div>
@@ -39,10 +39,10 @@ export default function Services() {
               <div className="w-16 h-16 mx-auto text-red-600 mb-4">
                 <Icon />
               </div>
-              <h3 className="text-xl font-medium text-gray-900 mb-2">
+              <h3 className="font-heading text-2xl text-primary mb-2">
                 {srv.title}
               </h3>
-              <p className="text-gray-600">{srv.desc}</p>
+              <p className="font-sans text-base text-primary">{srv.desc}</p>
             </div>
           );
         })}

--- a/frontend/src/components/Testimonials.tsx
+++ b/frontend/src/components/Testimonials.tsx
@@ -13,16 +13,16 @@ export default function Testimonials() {
   return (
     <div id="testimonials" className="py-20 bg-white">
       <div className="container mx-auto px-6 text-center mb-12">
-        <h2 className="text-3xl font-semibold text-gray-900">
+        <h2 className="font-heading text-3xl md:text-4xl text-primary text-center mb-8">
           {t("testimonials.title")}
         </h2>
       </div>
       <div className="container mx-auto px-6 grid grid-cols-1 md:grid-cols-2 gap-8">
         {reviews.map((r, idx) => (
           <div key={idx} className="p-6 bg-gray-50 rounded-lg shadow">
-            <blockquote className="text-gray-600 italic mb-4">“{r.text}”</blockquote>
-            <p className="text-gray-900 font-medium">{r.name}</p>
-            <p className="text-gray-500 text-sm">{r.role}</p>
+            <blockquote className="font-sans text-base text-primary italic mb-4">“{r.text}”</blockquote>
+            <p className="font-sans text-base text-primary font-medium">{r.name}</p>
+            <p className="font-sans text-base text-primary">{r.role}</p>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- use consistent fonts and sizes for h2 and h3
- standardize paragraph and span text styles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_687dee56511483278b9ff5d37837ae6b