### PR TITLE
Remove Telegram contact option

### DIFF
--- a/frontend/src/i18n/bg.json
+++ b/frontend/src/i18n/bg.json
@@ -87,7 +87,7 @@
   "languageSwitcher": { "label": "Език", "en": "English", "ru": "Русский", "bg": "Български" },
 
   "messengers": {
-    "title": "Пишете ни в чатовете",
+    "title": "Свържете се с нас",
     "phone": "Телефон",
     "viber": "Viber",
     "whatsapp": "WhatsApp",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -96,7 +96,7 @@
   },
 
   "messengers": {
-    "title": "Chat with us",
+    "title": "Contact us",
     "phone": "Phone",
     "viber": "Viber",
     "whatsapp": "WhatsApp",

--- a/frontend/src/i18n/ru.json
+++ b/frontend/src/i18n/ru.json
@@ -87,7 +87,7 @@
   "languageSwitcher": { "label": "Язык", "en": "English", "ru": "Русский", "bg": "Български" },
 
   "messengers": {
-    "title": "Напишите нам",
+    "title": "Свяжитесь с нами",
     "phone": "Телефон",
     "viber": "Viber",
     "whatsapp": "WhatsApp",


### PR DESCRIPTION
## Summary
- drop Telegram icon asset
- remove Telegram contact card from chat and contact sections
- update translations accordingly

## Testing
- `pre-commit run --files frontend/src/components/ChatModal.tsx frontend/src/components/ContactSection.tsx frontend/src/i18n/en.json frontend/src/i18n/ru.json frontend/src/i18n/bg.json frontend/src/assets/icons/telegram.svg` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e355d5d788327ba8d22d40e9dca1c