### PR TITLE
Enable external access via nginx proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,27 @@ fastapi-react-starter/
    - **Username:** `admin`
    - **Password:** `admin`
 
+### Running on a VPS
+
+If you want to expose the application to the internet, the `docker-compose.yml`
+includes an **nginx** service that listens on port `80` and proxies requests to
+the backend and frontend containers. Simply run the stack on your server:
+
+```bash
+docker compose up -d
+```
+
+Make sure your VPS firewall allows incoming connections on port `80` (and `443`
+if you later add TLS). On Ubuntu with UFW this can be enabled with:
+
+```bash
+sudo ufw allow 80/tcp
+```
+
+After starting the containers, the API will be reachable at
+`http://your-server-ip/api` and the React frontend will be served from
+`http://your-server-ip/`.
+
 ### Automated Setup Scripts
 
 For your convenience, this project includes automated setup scripts for both Windows and Linux/Mac:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,5 +60,18 @@ services:
         condition: service_healthy
     command: sh -c "npm install && npm run dev"
 
+  nginx:
+    image: nginx:alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      backend:
+        condition: service_healthy
+      frontend:
+        condition: service_started
+
 volumes:
   postgres_data:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,46 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+# Necessary events block
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    upstream backend {
+        server backend:8000;
+    }
+
+    upstream frontend {
+        server frontend:5173;
+    }
+
+    server {
+        listen 80;
+
+        location /api/ {
+            proxy_pass http://backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location / {
+            proxy_pass http://frontend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add nginx reverse proxy for exposing services on port 80
- show how to run on a VPS in README

## Testing
- `python3 -m pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pre-commit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880875a161c83279223801c703a66ce