### PR TITLE
Fix API URL for production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,13 @@ APP_DESCRIPTION="FastAPI React Starter Template"
 DATABASE_URL="sqlite+aiosqlite:///./app.db"
 
 # CORS Settings
+# Allowed origins for the backend CORS policy
+# Adjust when exposing the app on the internet or keep default for local usage
 CORS_ORIGINS=["http://localhost:5173"]
 
 
 # Frontend Settings
-VITE_API_URL=http://localhost:8000
+# API base URL for the frontend
+# Set to the backend address in development. Leave empty when serving both
+# frontend and backend from the same domain (e.g. in production with nginx).
+VITE_API_URL=

--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ fastapi-react-starter/
    - Start the FastAPI backend at http://localhost:8000
    - Start the React frontend at http://localhost:5173
 
+   The frontend expects the backend URL from the `VITE_API_URL` environment
+   variable. When running everything with Docker Compose the services share the
+   same domain, so you can leave this variable empty. For local development,
+   set it to `http://localhost:8000`.
+
    The Swagger docs will be available at http://localhost:8000/docs
 
    The first start creates an administrator account with:
@@ -163,6 +168,10 @@ sudo ufw allow 80/tcp
 After starting the containers, the API will be reachable at
 `http://your-server-ip/api` and the React frontend will be served from
 `http://your-server-ip/`.
+
+When using the provided `nginx` service the frontend can access the backend on
+the same domain. Ensure the `VITE_API_URL` variable is unset or empty so the
+application uses relative URLs.
 
 ### Automated Setup Scripts
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,10 @@ services:
       - ./frontend:/app
       - /app/node_modules
     environment:
-      - VITE_API_URL=http://localhost:8000
+      # Leave VITE_API_URL empty so the frontend uses the same host as the
+      # backend when served behind nginx. Set to http://localhost:8000 when
+      # running without the proxy.
+      - VITE_API_URL=
     depends_on:
       backend:
         condition: service_healthy

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,4 @@
+# API base URL used by the frontend
+# For local development point to the backend container or host
+# Leave empty when serving both frontend and backend from the same domain
 VITE_API_URL=http://localhost:8000

--- a/frontend/src/components/Contact.tsx
+++ b/frontend/src/components/Contact.tsx
@@ -4,7 +4,8 @@ import { useLanguage } from '../context/LanguageContext'
 import FeedbackModal from './FeedbackModal'
 import ContactSection from './ContactSection'
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+// Use the same origin by default so requests succeed behind a proxy
+const API_URL = import.meta.env.VITE_API_URL || ''
 
 export default function Contact() {
   const { t } = useLanguage()

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -2,7 +2,9 @@
 import { createContext, useReducer, useContext, ReactNode, useCallback, useEffect } from 'react'
 import { AuthState, LoginCredentials, RegisterCredentials, AuthResult, User } from '@/types/auth'
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+// When VITE_API_URL isn't set, use the current origin so the app works
+// both locally and behind a reverse proxy (e.g. nginx on a VPS).
+const API_URL = import.meta.env.VITE_API_URL || ''
 
 // --- Action types ---
 export const AUTH_ACTIONS = {


### PR DESCRIPTION
## Summary
- default API URL to same origin
- document API URL in env examples and README
- configure docker-compose to use empty API URL for nginx

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68809af4dff48327824b1d83c4a761a0