### PR TITLE
Use remote API URL and enable CORS

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -4,4 +4,7 @@
 DATABASE_URL=sqlite+aiosqlite:///./app.db
 
 # Разрешённые origin для CORS (React-приложение на 5173)
-CORS_ORIGINS=["http://localhost:5173"]
+CORS_ORIGINS=["http://localhost:5173", "http://154.43.62.173:5173"]
+
+# Frontend Settings
+VITE_API_BASE_URL=http://154.43.62.173:8000

--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,8 @@ APP_DESCRIPTION="FastAPI React Starter Template"
 DATABASE_URL="sqlite+aiosqlite:///./app.db"
 
 # CORS Settings
-CORS_ORIGINS=["http://localhost:5173"]
+CORS_ORIGINS=["http://localhost:5173", "http://154.43.62.173:5173"]
 
 
 # Frontend Settings
-VITE_API_URL=http://localhost:8000
+VITE_API_BASE_URL=http://154.43.62.173:8000

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -23,7 +23,7 @@ DB_ECHO=false
 #DB_SSL_MODE=disable  # Options: disable, allow, prefer, require, verify-ca, verify-full
 
 # CORS Settings
-CORS_ORIGINS=["http://localhost:5173"]
+CORS_ORIGINS=["http://localhost:5173", "http://154.43.62.173:5173"]
 
 # Environment
 ENVIRONMENT=development  # Options: development, production, testing

--- a/backend/app/config/config.py
+++ b/backend/app/config/config.py
@@ -13,7 +13,11 @@ class Settings(BaseSettings):
     APP_NAME: str = "FastAPI React Starter"
     APP_DESCRIPTION: str = "FastAPI React Starter Template"
     DATABASE_URL: str = "sqlite+aiosqlite:///./app.db"
-    CORS_ORIGINS: List[str] = ["http://localhost:5173", "http://localhost:3000"]
+    CORS_ORIGINS: List[str] = [
+        "http://localhost:5173",
+        "http://localhost:3000",
+        "http://154.43.62.173:5173",
+    ]
     API_PREFIX: str = "/api"
 
     # Database settings

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - DB_PASSWORD=${DB_PASSWORD:-postgres}
       - DB_HOST=postgres
       - DB_PORT=5432
-      - CORS_ORIGINS=["http://localhost:5173"]
+      - CORS_ORIGINS=["http://localhost:5173", "http://154.43.62.173:5173"]
       - ENVIRONMENT=development
       - ADMIN_PASSWORD=${ADMIN_PASSWORD:-qwerty1234}
     depends_on:
@@ -54,7 +54,7 @@ services:
       - ./frontend:/app
       - /app/node_modules
     environment:
-      - VITE_API_URL=http://localhost:8000
+      - VITE_API_BASE_URL=http://154.43.62.173:8000
     depends_on:
       backend:
         condition: service_healthy

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,1 @@
-VITE_API_URL=http://localhost:8000
+VITE_API_BASE_URL=http://154.43.62.173:8000

--- a/frontend/src/components/Contact.tsx
+++ b/frontend/src/components/Contact.tsx
@@ -4,7 +4,7 @@ import { useLanguage } from '../context/LanguageContext'
 import FeedbackModal from './FeedbackModal'
 import ContactSection from './ContactSection'
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+const API_URL = import.meta.env.VITE_API_BASE_URL || 'http://154.43.62.173:8000'
 
 export default function Contact() {
   const { t } = useLanguage()

--- a/frontend/src/components/JobList.tsx
+++ b/frontend/src/components/JobList.tsx
@@ -37,7 +37,7 @@ export default function JobList() {
   useEffect(() => {
     const fetchJobs = async () => {
       try {
-        const API = import.meta.env.VITE_API_URL || ''
+        const API = import.meta.env.VITE_API_BASE_URL || 'http://154.43.62.173:8000'
         const response = await axios.get<Job[]>(`${API}/api/jobs`, {
           params: { lang },
         })

--- a/frontend/src/components/admin/AdminApplicants.tsx
+++ b/frontend/src/components/admin/AdminApplicants.tsx
@@ -25,7 +25,7 @@ export default function AdminApplicants() {
   const handleDelete = async (id: number) => {
     if (!confirm('Delete this applicant?')) return
     try {
-      const API = import.meta.env.VITE_API_URL || ''
+      const API = import.meta.env.VITE_API_BASE_URL || 'http://154.43.62.173:8000'
       const token = localStorage.getItem('token') || ''
       const res = await fetch(`${API}/api/forms/${id}`, {
         method: 'DELETE',
@@ -47,7 +47,7 @@ export default function AdminApplicants() {
       setLoading(true)
       setError(null)
       try {
-        const API = import.meta.env.VITE_API_URL || ''
+        const API = import.meta.env.VITE_API_BASE_URL || 'http://154.43.62.173:8000'
         const token = localStorage.getItem('token') || ''
         const res = await fetch(`${API}/api/forms`, {
           headers: { Authorization: `Bearer ${token}` },

--- a/frontend/src/components/admin/AdminJobForm.tsx
+++ b/frontend/src/components/admin/AdminJobForm.tsx
@@ -76,7 +76,7 @@ export default function AdminJobForm() {
     if (!editMode) return
     ;(async () => {
       try {
-        const API = import.meta.env.VITE_API_URL || ''
+        const API = import.meta.env.VITE_API_BASE_URL || 'http://154.43.62.173:8000'
         const token = localStorage.getItem('token') || ''
         const res = await fetch(`${API}/api/jobs/${jobId}`, {
           headers: { Authorization: `Bearer ${token}` },
@@ -95,7 +95,7 @@ export default function AdminJobForm() {
     setSaving(true)
     setError(null)
     try {
-      const API = import.meta.env.VITE_API_URL || ''
+      const API = import.meta.env.VITE_API_BASE_URL || 'http://154.43.62.173:8000'
       const token = localStorage.getItem('token') || ''
       const url = editMode
         ? `${API}/api/jobs/${jobId}`
@@ -125,7 +125,7 @@ export default function AdminJobForm() {
     setSaving(true)
     setError(null)
     try {
-      const API = import.meta.env.VITE_API_URL || ''
+      const API = import.meta.env.VITE_API_BASE_URL || 'http://154.43.62.173:8000'
       const token = localStorage.getItem('token') || ''
       const res = await fetch(`${API}/api/jobs/${jobId}`, {
         method: 'DELETE',

--- a/frontend/src/components/admin/AdminJobList.tsx
+++ b/frontend/src/components/admin/AdminJobList.tsx
@@ -21,7 +21,7 @@ export default function AdminJobList() {
       setLoading(true)
       setError(null)
       try {
-        const API = import.meta.env.VITE_API_URL || ''
+        const API = import.meta.env.VITE_API_BASE_URL || 'http://154.43.62.173:8000'
         const token = localStorage.getItem('token') || ''
 
         const res = await fetch(`${API}/api/jobs`, {
@@ -48,7 +48,7 @@ export default function AdminJobList() {
   const handleDelete = async (id: number) => {
     if (!confirm('Delete this job?')) return
     try {
-      const API = import.meta.env.VITE_API_URL || ''
+      const API = import.meta.env.VITE_API_BASE_URL || 'http://154.43.62.173:8000'
       const token = localStorage.getItem('token') || ''
       const res = await fetch(`${API}/api/jobs/${id}`, {
         method: 'DELETE',

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -2,7 +2,7 @@
 import { createContext, useReducer, useContext, ReactNode, useCallback, useEffect } from 'react'
 import { AuthState, LoginCredentials, RegisterCredentials, AuthResult, User } from '@/types/auth'
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+const API_URL = import.meta.env.VITE_API_BASE_URL || 'http://154.43.62.173:8000'
 
 // --- Action types ---
 export const AUTH_ACTIONS = {

--- a/frontend/src/hooks/useHealthStatus.ts
+++ b/frontend/src/hooks/useHealthStatus.ts
@@ -10,7 +10,8 @@ export function useHealthStatus() {
 
 async function fetchHealthStatus() {
   try {
-    const response = await fetch(`${import.meta.env.VITE_API_URL}/api/health`)
+    const base = import.meta.env.VITE_API_BASE_URL || 'http://154.43.62.173:8000'
+    const response = await fetch(`${base}/api/health`)
     if (!response.ok) return { status: 'error' }
     const data = await response.json()
     return data

--- a/frontend/src/types/env.d.ts
+++ b/frontend/src/types/env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_API_URL: string
+  readonly VITE_API_BASE_URL: string
   // Add other env variables here
 }
 


### PR DESCRIPTION
## Summary
- expose API base URL in env files
- allow frontend origin in backend CORS settings
- use VITE_API_BASE_URL in React app
- update docker-compose to forward env var

## Testing
- `pnpm --dir frontend format:check` *(fails: code style issues)*
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_6880b709d8e88327949b22908395a413