### PR TITLE
Add bulstaff.eu domain to backend CORS configuration

### DIFF
--- a/backend/app/config/config.py
+++ b/backend/app/config/config.py
@@ -17,6 +17,8 @@ class Settings(BaseSettings):
         "http://localhost:5173",
         "http://localhost:3000",
         "http://154.43.62.173:5173",
+        "http://bulstaff.eu",
+        "https://bulstaff.eu",
     ]
     API_PREFIX: str = "/api"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - DB_PASSWORD=${DB_PASSWORD:-postgres}
       - DB_HOST=postgres
       - DB_PORT=5432
-      - CORS_ORIGINS=["http://localhost:5173", "http://154.43.62.173:5173"]
+      - CORS_ORIGINS=["http://localhost:5173", "http://154.43.62.173:5173", "http://bulstaff.eu", "https://bulstaff.eu"]
       - ENVIRONMENT=development
       - ADMIN_PASSWORD=${ADMIN_PASSWORD:-qwerty1234}
     depends_on:


### PR DESCRIPTION
## Summary
- allow requests from bulstaff.eu in the backend default CORS configuration
- ensure docker-compose environment CORS list includes the new bulstaff.eu origins

## Testing
- not run (configuration-only change)

------
https://chatgpt.com/codex/tasks/task_e_68dd10615bac83279fe7972559be99b4