### PR TITLE
Centralize frontend API base URL configuration

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -4,7 +4,7 @@
 DATABASE_URL=sqlite+aiosqlite:///./app.db
 
 # Разрешённые origin для CORS (React-приложение на 5173)
-CORS_ORIGINS=["http://localhost:5173", "http://154.43.62.173:5173"]
+CORS_ORIGINS=["http://localhost:5173"]
 
 # Frontend Settings
-VITE_API_BASE_URL=http://154.43.62.173:8000
+VITE_API_BASE_URL=http://backend:8000

--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,8 @@ APP_DESCRIPTION="FastAPI React Starter Template"
 DATABASE_URL="sqlite+aiosqlite:///./app.db"
 
 # CORS Settings
-CORS_ORIGINS=["http://localhost:5173", "http://154.43.62.173:5173"]
+CORS_ORIGINS=["http://localhost:5173"]
 
 
 # Frontend Settings
-VITE_API_BASE_URL=http://154.43.62.173:8000
+VITE_API_BASE_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -164,6 +164,13 @@ After starting the containers, the API will be reachable at
 `http://your-server-ip/api` and the React frontend will be served from
 `http://your-server-ip/`.
 
+> **Production builds**
+>
+> When building the frontend for production behind nginx, set the
+> `VITE_API_BASE_URL` environment variable to `/api` (or to the full public
+> backend URL) before running the build. This ensures all requests are routed
+> through the reverse proxy.
+
 ### Automated Setup Scripts
 
 For your convenience, this project includes automated setup scripts for both Windows and Linux/Mac:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - ./frontend:/app
       - /app/node_modules
     environment:
-      - VITE_API_BASE_URL=http://154.43.62.173:8000
+      - VITE_API_BASE_URL=http://backend:8000
     depends_on:
       backend:
         condition: service_healthy

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL=http://154.43.62.173:8000
+VITE_API_BASE_URL=http://localhost:8000

--- a/frontend/src/components/Contact.tsx
+++ b/frontend/src/components/Contact.tsx
@@ -3,8 +3,7 @@ import { useLocation } from 'react-router-dom'
 import { useLanguage } from '../context/LanguageContext'
 import FeedbackModal from './FeedbackModal'
 import ContactSection from './ContactSection'
-
-const API_URL = import.meta.env.VITE_API_BASE_URL || 'http://154.43.62.173:8000'
+import { API_BASE_URL } from '@/lib/api'
 
 export default function Contact() {
   const { t } = useLanguage()
@@ -47,7 +46,7 @@ export default function Contact() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     try {
-      const res = await fetch(`${API_URL}/api/forms/`, {
+      const res = await fetch(`${API_BASE_URL}/api/forms/`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/frontend/src/components/JobList.tsx
+++ b/frontend/src/components/JobList.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from 'react'
 import axios from 'axios'
 import { useLanguage } from '../context/LanguageContext'
+import { API_BASE_URL } from '@/lib/api'
 
 interface Job {
   id: number
@@ -37,8 +38,7 @@ export default function JobList() {
   useEffect(() => {
     const fetchJobs = async () => {
       try {
-        const API = import.meta.env.VITE_API_BASE_URL || 'http://154.43.62.173:8000'
-        const response = await axios.get<Job[]>(`${API}/api/jobs`, {
+        const response = await axios.get<Job[]>(`${API_BASE_URL}/api/jobs`, {
           params: { lang },
         })
         setJobs(response.data)

--- a/frontend/src/components/admin/AdminApplicants.tsx
+++ b/frontend/src/components/admin/AdminApplicants.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../../context/AuthContext'
 import Button from '../ui/Button'
+import { API_BASE_URL } from '@/lib/api'
 
 interface Applicant {
   id: number
@@ -25,9 +26,8 @@ export default function AdminApplicants() {
   const handleDelete = async (id: number) => {
     if (!confirm('Delete this applicant?')) return
     try {
-      const API = import.meta.env.VITE_API_BASE_URL || 'http://154.43.62.173:8000'
       const token = localStorage.getItem('token') || ''
-      const res = await fetch(`${API}/api/forms/${id}`, {
+      const res = await fetch(`${API_BASE_URL}/api/forms/${id}`, {
         method: 'DELETE',
         headers: { Authorization: `Bearer ${token}` },
       })
@@ -47,9 +47,8 @@ export default function AdminApplicants() {
       setLoading(true)
       setError(null)
       try {
-        const API = import.meta.env.VITE_API_BASE_URL || 'http://154.43.62.173:8000'
         const token = localStorage.getItem('token') || ''
-        const res = await fetch(`${API}/api/forms`, {
+        const res = await fetch(`${API_BASE_URL}/api/forms`, {
           headers: { Authorization: `Bearer ${token}` },
         })
         if (!res.ok) {

--- a/frontend/src/components/admin/AdminJobForm.tsx
+++ b/frontend/src/components/admin/AdminJobForm.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams } from 'react-router-dom'
 import Button from '../ui/Button'
 import Input from '../ui/input'
 import Textarea from '../ui/Textarea'
+import { API_BASE_URL } from '@/lib/api'
 
 type LangCode = 'en' | 'ru' | 'bg'
 const langs: LangCode[] = ['en', 'ru', 'bg']
@@ -76,9 +77,8 @@ export default function AdminJobForm() {
     if (!editMode) return
     ;(async () => {
       try {
-        const API = import.meta.env.VITE_API_BASE_URL || 'http://154.43.62.173:8000'
         const token = localStorage.getItem('token') || ''
-        const res = await fetch(`${API}/api/jobs/${jobId}`, {
+        const res = await fetch(`${API_BASE_URL}/api/jobs/${jobId}`, {
           headers: { Authorization: `Bearer ${token}` },
         })
         if (!res.ok) throw new Error(await res.text())
@@ -95,11 +95,10 @@ export default function AdminJobForm() {
     setSaving(true)
     setError(null)
     try {
-      const API = import.meta.env.VITE_API_BASE_URL || 'http://154.43.62.173:8000'
       const token = localStorage.getItem('token') || ''
       const url = editMode
-        ? `${API}/api/jobs/${jobId}`
-        : `${API}/api/jobs`
+        ? `${API_BASE_URL}/api/jobs/${jobId}`
+        : `${API_BASE_URL}/api/jobs`
       const method = editMode ? 'PUT' : 'POST'
 
       const res = await fetch(url, {
@@ -125,9 +124,8 @@ export default function AdminJobForm() {
     setSaving(true)
     setError(null)
     try {
-      const API = import.meta.env.VITE_API_BASE_URL || 'http://154.43.62.173:8000'
       const token = localStorage.getItem('token') || ''
-      const res = await fetch(`${API}/api/jobs/${jobId}`, {
+      const res = await fetch(`${API_BASE_URL}/api/jobs/${jobId}`, {
         method: 'DELETE',
         headers: { Authorization: `Bearer ${token}` },
       })

--- a/frontend/src/components/admin/AdminJobList.tsx
+++ b/frontend/src/components/admin/AdminJobList.tsx
@@ -2,6 +2,7 @@
 import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import Button from '../ui/Button'
+import { API_BASE_URL } from '@/lib/api'
 
 // тип вакансии
 interface Job {
@@ -21,10 +22,9 @@ export default function AdminJobList() {
       setLoading(true)
       setError(null)
       try {
-        const API = import.meta.env.VITE_API_BASE_URL || 'http://154.43.62.173:8000'
         const token = localStorage.getItem('token') || ''
 
-        const res = await fetch(`${API}/api/jobs`, {
+        const res = await fetch(`${API_BASE_URL}/api/jobs`, {
           headers: { Authorization: `Bearer ${token}` },
         })
 
@@ -48,9 +48,8 @@ export default function AdminJobList() {
   const handleDelete = async (id: number) => {
     if (!confirm('Delete this job?')) return
     try {
-      const API = import.meta.env.VITE_API_BASE_URL || 'http://154.43.62.173:8000'
       const token = localStorage.getItem('token') || ''
-      const res = await fetch(`${API}/api/jobs/${id}`, {
+      const res = await fetch(`${API_BASE_URL}/api/jobs/${id}`, {
         method: 'DELETE',
         headers: { Authorization: `Bearer ${token}` },
       })

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,8 +1,7 @@
 // frontend/src/context/AuthContext.tsx
 import { createContext, useReducer, useContext, ReactNode, useCallback, useEffect } from 'react'
 import { AuthState, LoginCredentials, RegisterCredentials, AuthResult, User } from '@/types/auth'
-
-const API_URL = import.meta.env.VITE_API_BASE_URL || 'http://154.43.62.173:8000'
+import { API_BASE_URL } from '@/lib/api'
 
 // --- Action types ---
 export const AUTH_ACTIONS = {
@@ -70,7 +69,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   // Fetch current user when we have a token
   const fetchCurrentUser = useCallback(async (token: string) => {
     try {
-      const res = await fetch(`${API_URL}/api/auth/me`, {
+      const res = await fetch(`${API_BASE_URL}/api/auth/me`, {
         headers: { Authorization: `Bearer ${token}` },
       })
       if (res.ok) {
@@ -92,7 +91,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     async (creds: LoginCredentials): Promise<AuthResult> => {
       dispatch({ type: AUTH_ACTIONS.SET_LOADING, payload: true })
       try {
-        const res = await fetch(`${API_URL}/api/auth/login`, {
+        const res = await fetch(`${API_BASE_URL}/api/auth/login`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(creds),
@@ -123,7 +122,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       dispatch({ type: AUTH_ACTIONS.SET_LOADING, payload: true })
       try {
         const { confirmPassword, ...reg } = creds
-        const res = await fetch(`${API_URL}/api/auth/register`, {
+        const res = await fetch(`${API_BASE_URL}/api/auth/register`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(reg),

--- a/frontend/src/hooks/useHealthStatus.ts
+++ b/frontend/src/hooks/useHealthStatus.ts
@@ -1,5 +1,9 @@
+import { API_BASE_URL } from '@/lib/api'
+
+type HealthStatusResponse = { status: string; message?: string }
+
 // Cache the promise to avoid creating a new one on every render
-let healthPromise = null
+let healthPromise: Promise<HealthStatusResponse> | null = null
 
 export function useHealthStatus() {
   if (!healthPromise) {
@@ -10,12 +14,12 @@ export function useHealthStatus() {
 
 async function fetchHealthStatus() {
   try {
-    const base = import.meta.env.VITE_API_BASE_URL || 'http://154.43.62.173:8000'
-    const response = await fetch(`${base}/api/health`)
+    const response = await fetch(`${API_BASE_URL}/api/health`)
     if (!response.ok) return { status: 'error' }
-    const data = await response.json()
+    const data = (await response.json()) as HealthStatusResponse
     return data
   } catch (error) {
-    return { status: 'error', message: error.message }
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    return { status: 'error', message }
   }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? window.location.origin;

--- a/frontend/src/types/env.d.ts
+++ b/frontend/src/types/env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_API_BASE_URL: string
+  readonly VITE_API_BASE_URL?: string
   // Add other env variables here
 }
 


### PR DESCRIPTION
## Summary
- add a shared API_BASE_URL helper that reads VITE_API_BASE_URL with a window.origin fallback
- refactor auth, contact, job, and admin components to consume the helper and drop hard-coded service URLs
- refresh environment examples, docker compose, and docs to use service names locally and note production VITE_API_BASE_URL setup

## Testing
- npm run build *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd12128a348327870f12c06d9b35e2