### PR TITLE
Use relative API requests by default

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,1 +1,5 @@
-export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? window.location.origin;
+const envBaseUrl = import.meta.env.VITE_API_BASE_URL?.trim();
+
+export const API_BASE_URL = envBaseUrl
+  ? envBaseUrl.replace(/\/$/, '')
+  : '';


### PR DESCRIPTION
## Summary
- ensure the frontend defaults to relative API requests when no base URL override is provided

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd31705ca883278041107866bdb701