### PR TITLE
Remove hardcoded API base URL from Docker frontend config

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -7,4 +7,5 @@ DATABASE_URL=sqlite+aiosqlite:///./app.db
 CORS_ORIGINS=["http://localhost:5173"]
 
 # Frontend Settings
-VITE_API_BASE_URL=http://backend:8000
+# Оставляем базовый URL пустым, чтобы фронтенд использовал относительные пути
+# (например, /api/...), которые корректно работают за Nginx/Cloudflare.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,8 +53,8 @@ services:
     volumes:
       - ./frontend:/app
       - /app/node_modules
-    environment:
-      - VITE_API_BASE_URL=http://backend:8000
+    # Не пробрасываем базовый URL API, чтобы фронтенд использовал относительные пути
+    # и оставался за одним origin с Nginx/Cloudflare.
     depends_on:
       backend:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- remove the Docker-specific VITE_API_BASE_URL override so the frontend uses relative /api paths behind Nginx/Cloudflare

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd375b9bb4832788d1e2a175cb7e69