### PR TITLE
Update default admin credentials to bulstaff account

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,9 @@ fastapi-react-starter/
 
    The first start creates an administrator account with:
 
-   - **Username:** `admin`
-   - **Password:** `admin`
+   - **Username:** `office`
+   - **Email:** `office@bulstaff.com`
+   - **Password:** `qwerty1234`
 
 ### Running on a VPS
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,8 +1,8 @@
 # backend/Dockerfile (Alpine-версия)
 FROM python:3.13-alpine AS base
 
-ARG ADMIN_USERNAME=admin
-ARG ADMIN_EMAIL=admin@example.com
+ARG ADMIN_USERNAME=office
+ARG ADMIN_EMAIL=office@bulstaff.com
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \

--- a/backend/app/db/database.py
+++ b/backend/app/db/database.py
@@ -92,12 +92,12 @@ async def _create_default_admin() -> None:
         if result.scalar_one_or_none():
             return
         admin = User(
-            email="admin@example.com",
-            username="admin",
+            email="office@bulstaff.com",
+            username="office",
             role="admin",
             is_superuser=True,
         )
-        admin.set_password("admin")
+        admin.set_password("qwerty1234")
         session.add(admin)
         await session.commit()
 

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -79,9 +79,9 @@ def create_superuser(
     # создаём таблицы, если ещё нет
     Base.metadata.create_all(bind=engine)
 
-    username = username or "admin"
-    email = email or "admin@example.com"
-    password = password or "changeme"
+    username = username or "office"
+    email = email or "office@bulstaff.com"
+    password = password or "qwerty1234"
 
     db = SessionLocal()
     exists = db.query(User).filter_by(username=username).first()

--- a/backend/tests/test_forms.py
+++ b/backend/tests/test_forms.py
@@ -33,8 +33,8 @@ async def client():
     app.dependency_overrides[get_db] = override_get_db
 
     async with async_session() as session:
-        admin = User(email="admin@example.com", username="admin", role="admin")
-        admin.set_password("password")
+        admin = User(email="office@bulstaff.com", username="office", role="admin")
+        admin.set_password("qwerty1234")
         session.add(admin)
         await session.commit()
 
@@ -65,7 +65,7 @@ async def test_form_submission_and_admin_view(client: AsyncClient):
 
     res = await client.post(
         "/api/auth/login",
-        json={"email": "admin@example.com", "password": "password"},
+        json={"email": "office@bulstaff.com", "password": "qwerty1234"},
     )
     assert res.status_code == 200
     token = res.json()["access_token"]
@@ -95,7 +95,7 @@ async def test_delete_form(client: AsyncClient):
 
     res = await client.post(
         "/api/auth/login",
-        json={"email": "admin@example.com", "password": "password"},
+        json={"email": "office@bulstaff.com", "password": "qwerty1234"},
     )
     token = res.json()["access_token"]
     headers = {"Authorization": f"Bearer {token}"}

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -35,8 +35,8 @@ async def client():
     app.dependency_overrides[get_db] = override_get_db
 
     async with async_session() as session:
-        admin = User(email="admin@example.com", username="admin", role="admin")
-        admin.set_password("password")
+        admin = User(email="office@bulstaff.com", username="office", role="admin")
+        admin.set_password("qwerty1234")
         session.add(admin)
         await session.commit()
 
@@ -55,7 +55,7 @@ async def test_admin_job_crud(client: AsyncClient):
     # Login as admin
     res = await client.post(
         "/api/auth/login",
-        json={"email": "admin@example.com", "password": "password"},
+        json={"email": "office@bulstaff.com", "password": "qwerty1234"},
     )
     assert res.status_code == 200
     token = res.json()["access_token"]
@@ -117,7 +117,7 @@ async def test_admin_job_crud(client: AsyncClient):
 async def test_delete_job_via_public_route(client: AsyncClient):
     res = await client.post(
         "/api/auth/login",
-        json={"email": "admin@example.com", "password": "password"},
+        json={"email": "office@bulstaff.com", "password": "qwerty1234"},
     )
     token = res.json()["access_token"]
     headers = {"Authorization": f"Bearer {token}"}
@@ -144,7 +144,7 @@ async def test_delete_job_via_public_route(client: AsyncClient):
 async def test_list_jobs_with_language(client: AsyncClient):
     res = await client.post(
         "/api/auth/login",
-        json={"email": "admin@example.com", "password": "password"},
+        json={"email": "office@bulstaff.com", "password": "qwerty1234"},
     )
     token = res.json()["access_token"]
     headers = {"Authorization": f"Bearer {token}"}


### PR DESCRIPTION
## Summary
- update the default admin seeding to create office@bulstaff.com with the expected credentials
- align CLI defaults, Docker build args, tests, and docs with the new admin account
- reinitialize the database so fresh environments will include the updated superuser

## Testing
- python - <<'PY'
import asyncio
from app.db.database import init_db

asyncio.run(init_db())
PY

------
https://chatgpt.com/codex/tasks/task_e_68de1c53a67083279ed8ea2fb133a5af