### PR TITLE
Protect admin routes with role checks

### DIFF
--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,15 +1,38 @@
 // frontend/src/components/ProtectedRoute.tsx
 import React from 'react'
-import { Navigate, useLocation } from 'react-router-dom'
+import { Link, Navigate, useLocation } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext'
 
 export function ProtectedRoute({ children }: { children: React.ReactNode }) {
-  const { isAuthenticated } = useAuth()
+  const { isAuthenticated, isLoading, user } = useAuth()
   const location = useLocation()
+
+  if (isLoading) {
+    return <div className="py-20 text-center text-sm text-muted-foreground">Проверка прав доступа…</div>
+  }
 
   if (!isAuthenticated) {
     // не авторизованы — на login
     return <Navigate to="/admin/login" state={{ from: location }} replace />
+  }
+
+  const isAdmin = user?.role === 'admin' || Boolean((user as { is_superuser?: boolean } | null)?.is_superuser)
+
+  if (!isAdmin) {
+    return (
+      <div className="flex min-h-[50vh] flex-col items-center justify-center gap-3 text-center">
+        <h2 className="text-2xl font-semibold">Недостаточно прав</h2>
+        <p className="max-w-md text-sm text-muted-foreground">
+          У вас нет доступа к административной панели. Обратитесь к администратору, если считаете, что это ошибка.
+        </p>
+        <Link
+          to="/"
+          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow hover:bg-primary/90"
+        >
+          Вернуться на сайт
+        </Link>
+      </div>
+    )
   }
 
   return <>{children}</>

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -21,7 +21,7 @@ type AuthAction =
 const getInitialState = (): AuthState => ({
   isAuthenticated: Boolean(localStorage.getItem('token')),
   token: localStorage.getItem('token'),
-  isLoading: false,
+  isLoading: Boolean(localStorage.getItem('token')),
   user: null,
 })
 
@@ -40,6 +40,7 @@ function authReducer(state: AuthState, action: AuthAction): AuthState {
         ...state,
         isAuthenticated: false,
         token: null,
+        isLoading: false,
         user: null,
       }
     case AUTH_ACTIONS.SET_LOADING:
@@ -67,6 +68,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   // Fetch current user when we have a token
   const fetchCurrentUser = useCallback(async (token: string) => {
+    dispatch({ type: AUTH_ACTIONS.SET_LOADING, payload: true })
     try {
       const res = await fetch(`${API_BASE_URL}/api/auth/me`, {
         headers: { Authorization: `Bearer ${token}` },
@@ -82,6 +84,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
       console.error('Failed to fetch user:', err)
       localStorage.removeItem('token')
       dispatch({ type: AUTH_ACTIONS.LOGOUT })
+    } finally {
+      dispatch({ type: AUTH_ACTIONS.SET_LOADING, payload: false })
     }
   }, [])
 

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -2,6 +2,7 @@ export interface User {
   id: string
   email: string
   role: 'user' | 'admin' | 'moderator'
+  is_superuser?: boolean
 }
 
 export interface LoginCredentials {


### PR DESCRIPTION
## Summary
- ensure the auth context preloads the current user while managing loading state
- gate protected admin routes to admin or superuser accounts and show a helpful denial message
- extend the user type to surface the optional superuser flag

## Testing
- npm run typecheck *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68de232e4ebc83279326ae9f3d2c9477