### PR TITLE
Add admin password change flow

### DIFF
--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -23,6 +23,11 @@ class LoginRequest(BaseModel):
     password: str
 
 
+class PasswordChangeRequest(BaseModel):
+    current_password: str
+    new_password: str
+
+
 class UserResponse(BaseModel):
     id: int
     email: str

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,97 @@
+import os
+import sys
+import httpx
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.main import app
+from app.db.models import Base, User
+from app.db.database import get_db
+
+DATABASE_URL = "sqlite+aiosqlite:///./test.db"
+
+
+@pytest_asyncio.fixture
+async def client():
+    if os.path.exists("./test.db"):
+        os.remove("./test.db")
+
+    engine = create_async_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+    async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async def override_get_db():
+        async with async_session() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    async with async_session() as session:
+        admin = User(email="office@bulstaff.com", username="office", role="admin")
+        admin.set_password("qwerty1234")
+        session.add(admin)
+        await session.commit()
+
+    transport = httpx.ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as ac:
+        yield ac
+
+    app.dependency_overrides.clear()
+    await engine.dispose()
+    if os.path.exists("./test.db"):
+        os.remove("./test.db")
+
+
+@pytest.mark.asyncio
+async def test_change_password_success(client: AsyncClient):
+    login_response = await client.post(
+        "/api/auth/login",
+        json={"email": "office@bulstaff.com", "password": "qwerty1234"},
+    )
+    assert login_response.status_code == 200
+    token = login_response.json()["access_token"]
+
+    change_response = await client.post(
+        "/api/auth/change-password",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"current_password": "qwerty1234", "new_password": "newpass123"},
+    )
+
+    assert change_response.status_code == 200
+    assert change_response.json()["message"] == "Password updated successfully"
+
+    new_login = await client.post(
+        "/api/auth/login",
+        json={"email": "office@bulstaff.com", "password": "newpass123"},
+    )
+    assert new_login.status_code == 200
+
+    old_login = await client.post(
+        "/api/auth/login",
+        json={"email": "office@bulstaff.com", "password": "qwerty1234"},
+    )
+    assert old_login.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_change_password_invalid_current_password(client: AsyncClient):
+    login_response = await client.post(
+        "/api/auth/login",
+        json={"email": "office@bulstaff.com", "password": "qwerty1234"},
+    )
+    token = login_response.json()["access_token"]
+
+    change_response = await client.post(
+        "/api/auth/change-password",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"current_password": "wrongpass", "new_password": "newpass123"},
+    )
+
+    assert change_response.status_code == 400
+    assert change_response.json()["detail"] == "Current password is incorrect"

--- a/frontend/src/components/admin/AdminChangePassword.tsx
+++ b/frontend/src/components/admin/AdminChangePassword.tsx
@@ -1,0 +1,96 @@
+import { FormEvent, useState } from 'react'
+import Button from '../ui/Button'
+import { useAuth } from '../../context/AuthContext'
+
+export default function AdminChangePassword() {
+  const { changePassword, isLoading } = useAuth()
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null)
+  const inputClasses =
+    'mt-1 w-full rounded border border-gray-300 dark:border-gray-700 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-accent'
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setFeedback(null)
+
+    if (newPassword !== confirmPassword) {
+      setFeedback({ type: 'error', message: 'New passwords do not match.' })
+      return
+    }
+
+    const result = await changePassword({ currentPassword, newPassword })
+    if (result.success) {
+      setFeedback({ type: 'success', message: 'Password updated successfully.' })
+      setCurrentPassword('')
+      setNewPassword('')
+      setConfirmPassword('')
+    } else {
+      setFeedback({ type: 'error', message: result.error ?? 'Unable to change password.' })
+    }
+  }
+
+  return (
+    <div className="max-w-lg space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold text-gray-900 dark:text-white">Change password</h2>
+        <p className="text-gray-600 dark:text-gray-300">
+          Update the credentials for your administrator account.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4 bg-white dark:bg-gray-800 p-6 rounded shadow-sm">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-200">Current password</label>
+          <input
+            type="password"
+            required
+            value={currentPassword}
+            onChange={(event) => setCurrentPassword(event.target.value)}
+            className={inputClasses}
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-200">New password</label>
+          <input
+            type="password"
+            required
+            value={newPassword}
+            onChange={(event) => setNewPassword(event.target.value)}
+            className={inputClasses}
+            minLength={8}
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-200">Confirm new password</label>
+          <input
+            type="password"
+            required
+            value={confirmPassword}
+            onChange={(event) => setConfirmPassword(event.target.value)}
+            className={inputClasses}
+            minLength={8}
+          />
+        </div>
+
+        <div className="flex items-center gap-4">
+          <Button type="submit" disabled={isLoading}>
+            {isLoading ? 'Saving…' : 'Update password'}
+          </Button>
+          {feedback && (
+            <span
+              className={`text-sm ${
+                feedback.type === 'success' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+              }`}
+            >
+              {feedback.message}
+            </span>
+          )}
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/components/admin/AdminSidebar.tsx
+++ b/frontend/src/components/admin/AdminSidebar.tsx
@@ -4,6 +4,7 @@ const links = [
   { to: '/admin/dashboard', label: 'Dashboard' },
   { to: '/admin/jobs',      label: 'Jobs'      },
   { to: '/admin/forms',     label: 'Applicants'},
+  { to: '/admin/security',  label: 'Security'  },
 ]
 
 export default function AdminSidebar() {

--- a/frontend/src/pages/AdminSecurity.tsx
+++ b/frontend/src/pages/AdminSecurity.tsx
@@ -1,0 +1,13 @@
+import AdminHeader from '../components/admin/AdminHeader'
+import AdminChangePassword from '../components/admin/AdminChangePassword'
+
+export default function AdminSecurity() {
+  return (
+    <div className="flex-1 flex flex-col">
+      <AdminHeader />
+      <div className="flex-1 overflow-y-auto p-6 bg-gray-50 dark:bg-gray-900/40">
+        <AdminChangePassword />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -21,6 +21,7 @@ const AdminLogin   = React.lazy(() => import('../pages/AdminLogin'))
 const Dashboard    = React.lazy(() => import('../pages/Dashboard'))
 const JobAdmin     = React.lazy(() => import('../pages/JobAdmin'))
 const AdminForms   = React.lazy(() => import('../pages/AdminForms'))
+const AdminSecurity = React.lazy(() => import('../pages/AdminSecurity'))
 
 // Админские компоненты (дочерние маршруты)
 const AdminJobList  = React.lazy(() => import('../components/admin/AdminJobList'))
@@ -107,6 +108,15 @@ export const router = createBrowserRouter([
         element: withSuspense(
           <ProtectedRoute>
             <AdminForms />
+          </ProtectedRoute>
+        ),
+      },
+
+      {
+        path: 'security',
+        element: withSuspense(
+          <ProtectedRoute>
+            <AdminSecurity />
           </ProtectedRoute>
         ),
       },

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -20,6 +20,11 @@ export interface AuthResult {
   error: string | null
 }
 
+export interface PasswordChangePayload {
+  currentPassword: string
+  newPassword: string
+}
+
 export interface AuthState {
   user: User | null
   token: string | null


### PR DESCRIPTION
## Summary
- add a password change schema and FastAPI endpoint that verifies the current password before updating
- expose a changePassword helper in the auth context and build an admin security screen for updating credentials
- cover the new endpoint with async API tests for both success and failure scenarios

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'httpx' in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de24a267508327a7a57f6c918b5cb9