### PR TITLE
Add agilityforms domain to backend CORS configuration

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -23,7 +23,7 @@ DB_ECHO=false
 #DB_SSL_MODE=disable  # Options: disable, allow, prefer, require, verify-ca, verify-full
 
 # CORS Settings
-CORS_ORIGINS=["http://localhost:5173", "http://154.43.62.173:5173"]
+CORS_ORIGINS=["http://localhost:5173", "http://154.43.62.173:5173", "http://bulstaff.agilityforms.com", "https://bulstaff.agilityforms.com"]
 
 # Environment
 ENVIRONMENT=development  # Options: development, production, testing

--- a/backend/app/config/config.py
+++ b/backend/app/config/config.py
@@ -19,6 +19,8 @@ class Settings(BaseSettings):
         "http://154.43.62.173:5173",
         "http://bulstaff.eu",
         "https://bulstaff.eu",
+        "http://bulstaff.agilityforms.com",
+        "https://bulstaff.agilityforms.com",
     ]
     API_PREFIX: str = "/api"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - DB_PASSWORD=${DB_PASSWORD:-postgres}
       - DB_HOST=postgres
       - DB_PORT=5432
-      - CORS_ORIGINS=["http://localhost:5173", "http://154.43.62.173:5173", "http://bulstaff.eu", "https://bulstaff.eu"]
+      - CORS_ORIGINS=["http://localhost:5173", "http://154.43.62.173:5173", "http://bulstaff.eu", "https://bulstaff.eu", "http://bulstaff.agilityforms.com", "https://bulstaff.agilityforms.com"]
       - ENVIRONMENT=development
       - ADMIN_PASSWORD=${ADMIN_PASSWORD:-qwerty1234}
     depends_on:


### PR DESCRIPTION
## Summary
- allow the bulstaff.agilityforms.com origin in the default FastAPI CORS settings
- propagate the new origin into docker-compose and environment examples for easy deployment updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de37ede9288327a7df90f9dc9f21da