### PR TITLE
Refine admin UI to use single light theme

### DIFF
--- a/frontend/src/components/admin/AdminChangePassword.tsx
+++ b/frontend/src/components/admin/AdminChangePassword.tsx
@@ -9,7 +9,7 @@ export default function AdminChangePassword() {
   const [confirmPassword, setConfirmPassword] = useState('')
   const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null)
   const inputClasses =
-    'mt-1 w-full rounded border border-gray-300 dark:border-gray-700 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-accent'
+    'mt-1 w-full rounded border border-gray-300 bg-white px-3 py-2 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/40'
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -34,15 +34,13 @@ export default function AdminChangePassword() {
   return (
     <div className="max-w-lg space-y-6">
       <div>
-        <h2 className="text-2xl font-semibold text-gray-900 dark:text-white">Change password</h2>
-        <p className="text-gray-600 dark:text-gray-300">
-          Update the credentials for your administrator account.
-        </p>
+        <h2 className="text-2xl font-semibold text-gray-900">Change password</h2>
+        <p className="text-gray-600">Update the credentials for your administrator account.</p>
       </div>
 
-      <form onSubmit={handleSubmit} className="space-y-4 bg-white dark:bg-gray-800 p-6 rounded shadow-sm">
+      <form onSubmit={handleSubmit} className="space-y-4 bg-white p-6 rounded-xl border border-gray-200 shadow-sm">
         <div>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-200">Current password</label>
+          <label className="block text-sm font-medium text-gray-700">Current password</label>
           <input
             type="password"
             required
@@ -53,7 +51,7 @@ export default function AdminChangePassword() {
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-200">New password</label>
+          <label className="block text-sm font-medium text-gray-700">New password</label>
           <input
             type="password"
             required
@@ -65,7 +63,7 @@ export default function AdminChangePassword() {
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-200">Confirm new password</label>
+          <label className="block text-sm font-medium text-gray-700">Confirm new password</label>
           <input
             type="password"
             required
@@ -82,9 +80,7 @@ export default function AdminChangePassword() {
           </Button>
           {feedback && (
             <span
-              className={`text-sm ${
-                feedback.type === 'success' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
-              }`}
+              className={`text-sm ${feedback.type === 'success' ? 'text-green-600' : 'text-red-600'}`}
             >
               {feedback.message}
             </span>

--- a/frontend/src/components/admin/AdminHeader.tsx
+++ b/frontend/src/components/admin/AdminHeader.tsx
@@ -13,9 +13,9 @@ export default function AdminHeader() {
   }
 
   return (
-    <header className="bg-gray-800 text-white flex items-center justify-between px-6 py-4">
+    <header className="bg-white border-b border-gray-200 text-gray-900 flex items-center justify-between px-6 py-4">
       <h1 className="text-xl font-semibold">Admin Panel</h1>
-      <Button variant="ghost" onClick={handleLogout}>
+      <Button variant="secondary" onClick={handleLogout}>
         Logout
       </Button>
     </header>

--- a/frontend/src/components/admin/AdminSidebar.tsx
+++ b/frontend/src/components/admin/AdminSidebar.tsx
@@ -9,17 +9,17 @@ const links = [
 
 export default function AdminSidebar() {
   return (
-    <aside className="w-48 bg-gray-100 dark:bg-gray-900 p-4">
-      <nav className="space-y-3">
+    <aside className="w-56 bg-white border-r border-gray-200 p-6">
+      <nav className="space-y-2">
         {links.map(({ to, label }) => (
           <NavLink
             key={to}
             to={to}
             className={({ isActive }) =>
-              `block px-3 py-2 rounded ${
+              `block rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
                 isActive
-                  ? 'bg-gray-300 dark:bg-gray-700 font-semibold'
-                  : 'hover:bg-gray-200 dark:hover:bg-gray-800'
+                  ? 'bg-accentCyan/10 text-accentGreen'
+                  : 'text-gray-700 hover:bg-gray-100'
               }`
             }
           >

--- a/frontend/src/pages/AdminForms.tsx
+++ b/frontend/src/pages/AdminForms.tsx
@@ -5,9 +5,9 @@ import AdminApplicants from '../components/admin/AdminApplicants'
 
 export default function AdminForms() {
   return (
-    <div className="flex-1">
+    <div className="flex-1 flex flex-col bg-gray-50">
       <AdminHeader />
-      <div className="p-6">
+      <div className="flex-1 p-8">
         <AdminApplicants />
       </div>
     </div>

--- a/frontend/src/pages/AdminSecurity.tsx
+++ b/frontend/src/pages/AdminSecurity.tsx
@@ -3,9 +3,9 @@ import AdminChangePassword from '../components/admin/AdminChangePassword'
 
 export default function AdminSecurity() {
   return (
-    <div className="flex-1 flex flex-col">
+    <div className="flex-1 flex flex-col bg-gray-50">
       <AdminHeader />
-      <div className="flex-1 overflow-y-auto p-6 bg-gray-50 dark:bg-gray-900/40">
+      <div className="flex-1 overflow-y-auto p-8">
         <AdminChangePassword />
       </div>
     </div>

--- a/frontend/src/pages/JobAdmin.tsx
+++ b/frontend/src/pages/JobAdmin.tsx
@@ -4,9 +4,9 @@ import AdminHeader from '../components/admin/AdminHeader'
 
 export default function JobAdmin() {
   return (
-    <div className="flex-1 flex flex-col">
+    <div className="flex-1 flex flex-col bg-gray-50">
       <AdminHeader />
-      <div className="flex-1">
+      <div className="flex-1 p-8">
         {/* Тут будут либо список, либо форма */}
         <Outlet />
       </div>


### PR DESCRIPTION
## Summary
- remove dark theme modifiers from the admin header, sidebar, and security form
- refresh admin pages with a consistent light background and spacing

## Testing
- pnpm --prefix frontend typecheck *(fails: pre-existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68de3a55489c8327a624811ae9fedcf3