### PR TITLE
Update CORS allowlist domain

### DIFF
--- a/backend/app/config/config.py
+++ b/backend/app/config/config.py
@@ -17,10 +17,10 @@ class Settings(BaseSettings):
         "http://localhost:5173",
         "http://localhost:3000",
         "http://154.43.62.173:5173",
-        "http://bulstaff.eu",
-        "https://bulstaff.eu",
-        "http://bulstaff.agilityforms.com",
-        "https://bulstaff.agilityforms.com",
+        "http://budstaff.eu",
+        "https://budstaff.eu",
+        "http://budstaff.agilityforms.com",
+        "https://budstaff.agilityforms.com",
     ]
     API_PREFIX: str = "/api"
 


### PR DESCRIPTION
## Summary
- replace the bulstaff domain entries in the backend CORS allowlist with budstaff equivalents to match the correct hostnames

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de4066d618832789030b7c4a77b813